### PR TITLE
Added OTA tools 

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
     - [Telemetry Management](#telemetry-management)
     - [Relations](#relations)
     - [Alarms](#alarms)
+    - [OTA Packages](#ota-packages)
     - [Entity Data Query](#entity-data-query)
 - [Quick Start Guide](#quick-start-guide)
 - [Installation](#installation)
@@ -26,6 +27,7 @@
     - [Customer Tools](#customer-tools)
     - [User Tools](#user-tools)
     - [Alarm Tools](#alarm-tools)
+    - [OTA Tools](#ota-tools)
     - [Entity Group Tools](#entity-group-tools-pe)
     - [Relation Tools](#relation-tools)
     - [Telemetry Tools](#telemetry-tools)
@@ -103,6 +105,10 @@ Create, delete, discover, and navigate relationships between entities with direc
 ### Alarms
 
 Create, delete, fetch alarms, alarm types, and severity information for specific entities.
+
+### OTA Packages
+
+Create, upload, list, download, and delete OTA packages for device firmware/software updates.
 
 ### Entity Data Query
 
@@ -350,6 +356,22 @@ The ThingsBoard MCP Server provides a wide range of tools that can be used throu
 | `getAllAlarms`            | Get a page of alarms that belongs to the current user owner.                                                 |
 | `getHighestAlarmSeverity` | Get highest alarm severity by originator and optional status filters.                                        |
 | `getAlarmTypes`           | Get a set of unique alarm types based on alarms that are either owned by tenant or assigned to the customer. |
+
+### OTA Tools
+
+| Tool                             | Description                                                                 |
+|----------------------------------|-----------------------------------------------------------------------------|
+| `saveOtaPackageInfo`             | Create or update OTA package info.                                          |
+| `saveOtaPackageData`             | Upload OTA package binary data from a file path on the MCP host.            |
+| `downloadOtaPackage`             | Download OTA package binary to a local file path on the MCP host.           |
+| `getOtaPackageInfoById`          | Get OTA package info by id.                                                 |
+| `getOtaPackageById`              | Get OTA package by id.                                                      |
+| `getOtaPackages`                 | Get OTA packages (paged).                                                   |
+| `getOtaPackagesByDeviceProfile`  | Get OTA packages by device profile and type (paged).                        |
+| `assignOtaPackageToDevice`       | Assign or clear OTA package for a device.                                   |
+| `assignOtaPackageToDeviceProfile`| Assign or clear OTA package for a device profile.                           |
+| `countByDeviceProfileAndEmptyOtaPackage` | Count devices in a profile without assigned OTA package.           |
+| `deleteOtaPackage`               | Delete OTA package by id.                                                   |
 
 ### Entity Group Tools (PE)
 

--- a/README.md
+++ b/README.md
@@ -362,7 +362,7 @@ The ThingsBoard MCP Server provides a wide range of tools that can be used throu
 | Tool                             | Description                                                                 |
 |----------------------------------|-----------------------------------------------------------------------------|
 | `saveOtaPackageInfo`             | Create or update OTA package info.                                          |
-| `saveOtaPackageData`             | Upload OTA package binary data from a file path on the MCP host.            |
+| `saveOtaPackageData`             | Upload OTA package binary data from a file path on the MCP host. Provide `checksum` only if you already have an official hash. |
 | `downloadOtaPackage`             | Download OTA package binary to a local file path on the MCP host.           |
 | `getOtaPackageInfoById`          | Get OTA package info by id.                                                 |
 | `getOtaPackageById`              | Get OTA package by id.                                                      |

--- a/src/main/java/org/thingsboard/ai/mcp/server/rest/RestClient.java
+++ b/src/main/java/org/thingsboard/ai/mcp/server/rest/RestClient.java
@@ -3591,6 +3591,7 @@ public class RestClient implements Closeable {
 
         if (checkSum != null) {
             url += "&checkSum={checkSum}";
+            params.put("checkSum", checkSum);
         }
 
         return restTemplate.postForEntity(

--- a/src/main/java/org/thingsboard/ai/mcp/server/tools/ota/OtaTools.java
+++ b/src/main/java/org/thingsboard/ai/mcp/server/tools/ota/OtaTools.java
@@ -82,10 +82,7 @@ public class OtaTools implements McpTools {
             @ToolParam(description = "A string value representing the OTA package id.") @NotBlank String otaPackageId,
             @ToolParam(description = "File path to OTA binary on the MCP host.") @NotBlank String filePath,
             @ToolParam(required = false, description = "Checksum algorithm: MD5, SHA256, SHA384, SHA512. Default: SHA256.") String checksumAlgorithm,
-            @ToolParam(required = false, description = "Optional checksum (hex). If omitted, checksum is computed from file.") String checksum) throws Exception {
-        if (!StringUtils.isBlank(checksum)) {
-            return errorJson("Checksum input is not supported yet. Omit checksum to let ThingsBoard compute it.");
-        }
+            @ToolParam(required = false, description = "Optional checksum (hex). Provide only if you already have an official hash; otherwise omit and let ThingsBoard compute it.") String checksum) throws Exception {
         Path path = Paths.get(filePath);
         if (!Files.exists(path)) {
             return errorJson("File not found: " + filePath);
@@ -93,7 +90,7 @@ public class OtaTools implements McpTools {
         byte[] bytes = Files.readAllBytes(path);
         String fileName = path.getFileName().toString();
         ChecksumAlgorithm algo = parseChecksumAlgorithm(checksumAlgorithm);
-        String digest = null;
+        String digest = StringUtils.isBlank(checksum) ? null : checksum.trim();
         return JacksonUtil.toString(clientService.getClient().saveOtaPackageData(new OtaPackageId(UUID.fromString(otaPackageId)), digest, algo, fileName, bytes));
     }
 

--- a/src/main/java/org/thingsboard/ai/mcp/server/tools/ota/OtaTools.java
+++ b/src/main/java/org/thingsboard/ai/mcp/server/tools/ota/OtaTools.java
@@ -1,0 +1,249 @@
+package org.thingsboard.ai.mcp.server.tools.ota;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.PositiveOrZero;
+import lombok.RequiredArgsConstructor;
+import org.springframework.ai.tool.annotation.Tool;
+import org.springframework.ai.tool.annotation.ToolParam;
+import org.springframework.core.io.Resource;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.thingsboard.ai.mcp.server.rest.RestClientService;
+import org.thingsboard.ai.mcp.server.tools.McpTools;
+import org.thingsboard.common.util.JacksonUtil;
+import org.thingsboard.server.common.data.OtaPackageInfo;
+import org.thingsboard.server.common.data.StringUtils;
+import org.thingsboard.server.common.data.ota.ChecksumAlgorithm;
+import org.thingsboard.server.common.data.ota.OtaPackageType;
+import org.thingsboard.server.common.data.Device;
+import org.thingsboard.server.common.data.DeviceProfile;
+import org.thingsboard.server.common.data.exception.ThingsboardException;
+import org.thingsboard.server.common.data.id.DeviceId;
+import org.thingsboard.server.common.data.id.DeviceProfileId;
+import org.thingsboard.server.common.data.id.OtaPackageId;
+import org.thingsboard.server.common.data.page.PageLink;
+
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.thingsboard.ai.mcp.server.constant.ControllerConstants.PAGE_DATA_PARAMETERS;
+import static org.thingsboard.ai.mcp.server.constant.ControllerConstants.PAGE_NUMBER_DESCRIPTION;
+import static org.thingsboard.ai.mcp.server.constant.ControllerConstants.PAGE_SIZE_DESCRIPTION;
+import static org.thingsboard.ai.mcp.server.constant.ControllerConstants.SORT_ORDER_DESCRIPTION;
+import static org.thingsboard.ai.mcp.server.constant.ControllerConstants.SORT_PROPERTY_DESCRIPTION;
+import static org.thingsboard.ai.mcp.server.constant.ControllerConstants.TENANT_AUTHORITY_PARAGRAPH;
+import static org.thingsboard.ai.mcp.server.util.ToolUtils.createPageLink;
+
+@Service
+@RequiredArgsConstructor
+public class OtaTools implements McpTools {
+
+    private static final String OTA_PACKAGE_JSON_EXAMPLE =
+            """
+                    ```json
+                    {
+                      \"id\": { \"entityType\": \"OTA_PACKAGE\", \"id\": \"d3cfc080-a295-11f0-848c-93db0ade7d93\" },
+                      \"tenantId\": { \"entityType\": \"TENANT\", \"id\": \"d3cfc080-a295-11f0-848c-93db0ade7d93\" },
+                      \"deviceProfileId\": { \"entityType\": \"DEVICE_PROFILE\", \"id\": \"716a92d0-9d36-11f0-a79c-e726b4e8048a\" },
+                      \"type\": \"FIRMWARE\",
+                      \"title\": \"tracker_lorawan_heltec\",
+                      \"version\": \"1.0.32\",
+                      \"tag\": \"tracker_lorawan_heltec 1.0.32\",
+                      \"url\": null,
+                      \"additionalInfo\": { \"description\": \"Heltec tracker OTA\" }
+                    }
+                    ```""";
+
+    private final RestClientService clientService;
+
+    @Tool(description = "Create or update OTA package info. Omit 'id' to create a new package; include 'id' to update existing package." +
+            TENANT_AUTHORITY_PARAGRAPH)
+    public String saveOtaPackageInfo(
+            @ToolParam(description = "A JSON string representing the OTA package info. " + OTA_PACKAGE_JSON_EXAMPLE)
+            @NotBlank @Valid String otaPackageInfoJson,
+            @ToolParam(required = false, description = "If true, the OTA package uses a URL instead of uploaded binary data.")
+            Boolean isUrl) {
+        OtaPackageInfo otaPackageInfo = JacksonUtil.fromString(otaPackageInfoJson, OtaPackageInfo.class);
+        boolean useUrl = isUrl != null && isUrl;
+        return JacksonUtil.toString(clientService.getClient().saveOtaPackageInfo(otaPackageInfo, useUrl));
+    }
+
+    @Tool(description = "Upload OTA package binary data from a file path on the MCP host. If checksum is omitted, it is computed automatically." +
+            TENANT_AUTHORITY_PARAGRAPH)
+    public String saveOtaPackageData(
+            @ToolParam(description = "A string value representing the OTA package id.") @NotBlank String otaPackageId,
+            @ToolParam(description = "File path to OTA binary on the MCP host.") @NotBlank String filePath,
+            @ToolParam(required = false, description = "Checksum algorithm: MD5, SHA256, SHA384, SHA512. Default: SHA256.") String checksumAlgorithm,
+            @ToolParam(required = false, description = "Optional checksum (hex). If omitted, checksum is computed from file.") String checksum) throws Exception {
+        Path path = Paths.get(filePath);
+        if (!Files.exists(path)) {
+            return errorJson("File not found: " + filePath);
+        }
+        byte[] bytes = Files.readAllBytes(path);
+        String fileName = path.getFileName().toString();
+        ChecksumAlgorithm algo = parseChecksumAlgorithm(checksumAlgorithm);
+        String digest = StringUtils.isBlank(checksum) ? null : checksum;
+        return JacksonUtil.toString(clientService.getClient().saveOtaPackageData(new OtaPackageId(UUID.fromString(otaPackageId)), digest, algo, fileName, bytes));
+    }
+
+    @Tool(description = "Download OTA package binary to a local file path on the MCP host." + TENANT_AUTHORITY_PARAGRAPH)
+    public String downloadOtaPackage(
+            @ToolParam(description = "A string value representing the OTA package id.") @NotBlank String otaPackageId,
+            @ToolParam(description = "Destination file path (or directory) on the MCP host.") @NotBlank String destinationPath) throws Exception {
+        ResponseEntity<Resource> response = clientService.getClient().downloadOtaPackage(new OtaPackageId(UUID.fromString(otaPackageId)));
+        Resource resource = response.getBody();
+        if (resource == null) {
+            Map<String, Object> err = new HashMap<>();
+            err.put("status", "ERROR");
+            err.put("message", "No data returned for OTA package download");
+            return JacksonUtil.toString(err);
+        }
+        Path target = Paths.get(destinationPath);
+        if (Files.exists(target) && Files.isDirectory(target)) {
+            String name = resource.getFilename() != null ? resource.getFilename() : (otaPackageId + ".bin");
+            target = target.resolve(name);
+        }
+        Path parent = target.getParent();
+        if (parent != null) {
+            Files.createDirectories(parent);
+        }
+        try (InputStream in = resource.getInputStream()) {
+            Files.copy(in, target, java.nio.file.StandardCopyOption.REPLACE_EXISTING);
+        }
+        Map<String, Object> result = new HashMap<>();
+        result.put("status", "OK");
+        result.put("path", target.toString());
+        return JacksonUtil.toString(result);
+    }
+
+    @Tool(description = "Get OTA package info by id." + TENANT_AUTHORITY_PARAGRAPH)
+    public String getOtaPackageInfoById(
+            @ToolParam(description = "A string value representing the OTA package id.") @NotBlank String otaPackageId) {
+        return JacksonUtil.toString(clientService.getClient().getOtaPackageInfoById(new OtaPackageId(UUID.fromString(otaPackageId))));
+    }
+
+    @Tool(description = "Get OTA package by id." + TENANT_AUTHORITY_PARAGRAPH)
+    public String getOtaPackageById(
+            @ToolParam(description = "A string value representing the OTA package id.") @NotBlank String otaPackageId) {
+        return JacksonUtil.toString(clientService.getClient().getOtaPackageById(new OtaPackageId(UUID.fromString(otaPackageId))));
+    }
+
+    @Tool(description = "Get OTA packages (paged). " + PAGE_DATA_PARAMETERS + TENANT_AUTHORITY_PARAGRAPH)
+    public String getOtaPackages(
+            @ToolParam(description = PAGE_SIZE_DESCRIPTION) @Positive String pageSize,
+            @ToolParam(description = PAGE_NUMBER_DESCRIPTION) @PositiveOrZero String page,
+            @ToolParam(required = false, description = "The case insensitive 'substring' filter based on the OTA package title.") String textSearch,
+            @ToolParam(required = false, description = SORT_PROPERTY_DESCRIPTION + ". Allowed values: 'createdTime', 'title', 'version', 'tag', 'name'") String sortProperty,
+            @ToolParam(required = false, description = SORT_ORDER_DESCRIPTION) String sortOrder) throws ThingsboardException {
+        PageLink pageLink = createPageLink(pageSize, page, textSearch, sortProperty, sortOrder);
+        return JacksonUtil.toString(clientService.getClient().getOtaPackages(pageLink));
+    }
+
+    @Tool(description = "Get OTA packages by device profile and type (paged). " + PAGE_DATA_PARAMETERS + TENANT_AUTHORITY_PARAGRAPH)
+    public String getOtaPackagesByDeviceProfile(
+            @ToolParam(description = "A string value representing the device profile id.") @NotBlank String deviceProfileId,
+            @ToolParam(description = "OTA package type. Allowed values: FIRMWARE or SOFTWARE.") @NotBlank String otaPackageType,
+            @ToolParam(required = false, description = "Filter only packages that have data (default: true).") Boolean hasData,
+            @ToolParam(description = PAGE_SIZE_DESCRIPTION) @Positive String pageSize,
+            @ToolParam(description = PAGE_NUMBER_DESCRIPTION) @PositiveOrZero String page,
+            @ToolParam(required = false, description = "The case insensitive 'substring' filter based on the OTA package title.") String textSearch,
+            @ToolParam(required = false, description = SORT_PROPERTY_DESCRIPTION + ". Allowed values: 'createdTime', 'title', 'version', 'tag', 'name'") String sortProperty,
+            @ToolParam(required = false, description = SORT_ORDER_DESCRIPTION) String sortOrder) throws ThingsboardException {
+        PageLink pageLink = createPageLink(pageSize, page, textSearch, sortProperty, sortOrder);
+        boolean hasDataValue = hasData == null || hasData;
+        OtaPackageType type = OtaPackageType.valueOf(otaPackageType.trim().toUpperCase());
+        return JacksonUtil.toString(clientService.getClient().getOtaPackages(new DeviceProfileId(UUID.fromString(deviceProfileId)), type, hasDataValue, pageLink));
+    }
+
+    @Tool(description = "Count devices in a profile that do not have assigned OTA package." + TENANT_AUTHORITY_PARAGRAPH)
+    public String countByDeviceProfileAndEmptyOtaPackage(
+            @ToolParam(description = "A string value representing the device profile id.") @NotBlank String deviceProfileId,
+            @ToolParam(description = "OTA package type. Allowed values: FIRMWARE or SOFTWARE.") @NotBlank String otaPackageType) {
+        OtaPackageType type = OtaPackageType.valueOf(otaPackageType.trim().toUpperCase());
+        long count = clientService.getClient().countByDeviceProfileAndEmptyOtaPackage(type, new DeviceProfileId(UUID.fromString(deviceProfileId)));
+        Map<String, Object> result = new HashMap<>();
+        result.put("count", count);
+        return JacksonUtil.toString(result);
+    }
+
+    @Tool(description = "Assign OTA package to a device (firmware/software). If clear is true, clears assignment." +
+            TENANT_AUTHORITY_PARAGRAPH)
+    public String assignOtaPackageToDevice(
+            @ToolParam(description = "A string value representing the device id.") @NotBlank String deviceId,
+            @ToolParam(required = false, description = "A string value representing the OTA package id.") String otaPackageId,
+            @ToolParam(description = "OTA package type. Allowed values: FIRMWARE or SOFTWARE.") @NotBlank String otaPackageType,
+            @ToolParam(required = false, description = "If true, clears the OTA package assignment.") Boolean clear) {
+        boolean doClear = clear != null && clear;
+        if (!doClear && StringUtils.isBlank(otaPackageId)) {
+            return errorJson("otaPackageId is required unless clear=true");
+        }
+        OtaPackageType type = OtaPackageType.valueOf(otaPackageType.trim().toUpperCase());
+        Optional<Device> deviceOpt = clientService.getClient().getDeviceById(new DeviceId(UUID.fromString(deviceId)));
+        if (deviceOpt.isEmpty()) {
+            return errorJson("Device not found: " + deviceId);
+        }
+        Device device = deviceOpt.get();
+        OtaPackageId pkgId = doClear ? null : new OtaPackageId(UUID.fromString(otaPackageId));
+        if (type == OtaPackageType.FIRMWARE) {
+            device.setFirmwareId(pkgId);
+        } else {
+            device.setSoftwareId(pkgId);
+        }
+        return JacksonUtil.toString(clientService.getClient().saveDevice(device));
+    }
+
+    @Tool(description = "Assign OTA package to a device profile (firmware/software). If clear is true, clears assignment." +
+            TENANT_AUTHORITY_PARAGRAPH)
+    public String assignOtaPackageToDeviceProfile(
+            @ToolParam(description = "A string value representing the device profile id.") @NotBlank String deviceProfileId,
+            @ToolParam(required = false, description = "A string value representing the OTA package id.") String otaPackageId,
+            @ToolParam(description = "OTA package type. Allowed values: FIRMWARE or SOFTWARE.") @NotBlank String otaPackageType,
+            @ToolParam(required = false, description = "If true, clears the OTA package assignment.") Boolean clear) {
+        boolean doClear = clear != null && clear;
+        if (!doClear && StringUtils.isBlank(otaPackageId)) {
+            return errorJson("otaPackageId is required unless clear=true");
+        }
+        OtaPackageType type = OtaPackageType.valueOf(otaPackageType.trim().toUpperCase());
+        Optional<DeviceProfile> profileOpt = clientService.getClient().getDeviceProfileById(new DeviceProfileId(UUID.fromString(deviceProfileId)));
+        if (profileOpt.isEmpty()) {
+            return errorJson("Device profile not found: " + deviceProfileId);
+        }
+        DeviceProfile profile = profileOpt.get();
+        OtaPackageId pkgId = doClear ? null : new OtaPackageId(UUID.fromString(otaPackageId));
+        if (type == OtaPackageType.FIRMWARE) {
+            profile.setFirmwareId(pkgId);
+        } else {
+            profile.setSoftwareId(pkgId);
+        }
+        return JacksonUtil.toString(clientService.getClient().saveDeviceProfile(profile));
+    }
+
+    @Tool(description = "Delete OTA package by id." + TENANT_AUTHORITY_PARAGRAPH)
+    public String deleteOtaPackage(
+            @ToolParam(description = "A string value representing the OTA package id.") @NotBlank String otaPackageId) {
+        clientService.getClient().deleteOtaPackage(new OtaPackageId(UUID.fromString(otaPackageId)));
+        return "{\"status\":\"OK\",\"id\":\"" + otaPackageId + "\"}";
+    }
+
+    private static ChecksumAlgorithm parseChecksumAlgorithm(String checksumAlgorithm) {
+        if (StringUtils.isBlank(checksumAlgorithm)) {
+            return ChecksumAlgorithm.SHA256;
+        }
+        return ChecksumAlgorithm.valueOf(checksumAlgorithm.trim().toUpperCase());
+    }
+
+    private static String errorJson(String message) {
+        Map<String, Object> err = new HashMap<>();
+        err.put("status", "ERROR");
+        err.put("message", message);
+        return JacksonUtil.toString(err);
+    }
+}

--- a/src/main/java/org/thingsboard/ai/mcp/server/tools/ota/OtaTools.java
+++ b/src/main/java/org/thingsboard/ai/mcp/server/tools/ota/OtaTools.java
@@ -83,6 +83,9 @@ public class OtaTools implements McpTools {
             @ToolParam(description = "File path to OTA binary on the MCP host.") @NotBlank String filePath,
             @ToolParam(required = false, description = "Checksum algorithm: MD5, SHA256, SHA384, SHA512. Default: SHA256.") String checksumAlgorithm,
             @ToolParam(required = false, description = "Optional checksum (hex). If omitted, checksum is computed from file.") String checksum) throws Exception {
+        if (!StringUtils.isBlank(checksum)) {
+            return errorJson("Checksum input is not supported yet. Omit checksum to let ThingsBoard compute it.");
+        }
         Path path = Paths.get(filePath);
         if (!Files.exists(path)) {
             return errorJson("File not found: " + filePath);
@@ -90,7 +93,7 @@ public class OtaTools implements McpTools {
         byte[] bytes = Files.readAllBytes(path);
         String fileName = path.getFileName().toString();
         ChecksumAlgorithm algo = parseChecksumAlgorithm(checksumAlgorithm);
-        String digest = StringUtils.isBlank(checksum) ? null : checksum;
+        String digest = null;
         return JacksonUtil.toString(clientService.getClient().saveOtaPackageData(new OtaPackageId(UUID.fromString(otaPackageId)), digest, algo, fileName, bytes));
     }
 

--- a/src/test/java/org/thingsboard/ai/mcp/server/service/tools/OtaToolsTest.java
+++ b/src/test/java/org/thingsboard/ai/mcp/server/service/tools/OtaToolsTest.java
@@ -1,0 +1,289 @@
+package org.thingsboard.ai.mcp.server.service.tools;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.core.io.Resource;
+import org.springframework.http.ResponseEntity;
+import org.thingsboard.ai.mcp.server.rest.RestClient;
+import org.thingsboard.ai.mcp.server.rest.RestClientService;
+import org.thingsboard.ai.mcp.server.tools.ota.OtaTools;
+import org.thingsboard.common.util.JacksonUtil;
+import org.thingsboard.server.common.data.Device;
+import org.thingsboard.server.common.data.DeviceProfile;
+import org.thingsboard.server.common.data.OtaPackage;
+import org.thingsboard.server.common.data.OtaPackageInfo;
+import org.thingsboard.server.common.data.id.DeviceId;
+import org.thingsboard.server.common.data.id.DeviceProfileId;
+import org.thingsboard.server.common.data.id.OtaPackageId;
+import org.thingsboard.server.common.data.ota.ChecksumAlgorithm;
+import org.thingsboard.server.common.data.ota.OtaPackageType;
+import org.thingsboard.server.common.data.page.PageData;
+import org.thingsboard.server.common.data.page.PageLink;
+import org.thingsboard.server.common.data.page.SortOrder;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class OtaToolsTest {
+
+    @InjectMocks
+    private OtaTools tools;
+
+    @Mock
+    private RestClientService clientService;
+
+    @Mock
+    private RestClient restClient;
+
+    @Captor
+    private ArgumentCaptor<PageLink> pageLinkCaptor;
+
+    @TempDir
+    Path tempDir;
+
+    @BeforeEach
+    void setUp() {
+        lenient().when(clientService.getClient()).thenReturn(restClient);
+    }
+
+    @Test
+    void testSaveOtaPackageInfo() {
+        OtaPackageInfo info = new OtaPackageInfo();
+        info.setId(new OtaPackageId(UUID.randomUUID()));
+        when(restClient.saveOtaPackageInfo(any(OtaPackageInfo.class), eq(true))).thenReturn(info);
+
+        String result = tools.saveOtaPackageInfo(JacksonUtil.toString(info), true);
+
+        ArgumentCaptor<OtaPackageInfo> infoCaptor = ArgumentCaptor.forClass(OtaPackageInfo.class);
+        verify(restClient).saveOtaPackageInfo(infoCaptor.capture(), eq(true));
+        assertThat(infoCaptor.getValue().getId()).isEqualTo(info.getId());
+        assertThat(result).isEqualTo(JacksonUtil.toString(info));
+    }
+
+    @Test
+    void testSaveOtaPackageData() throws Exception {
+        UUID pkgUuid = UUID.randomUUID();
+        Path file = Files.createTempFile(tempDir, "ota-", ".bin");
+        byte[] payload = "ota-payload".getBytes(StandardCharsets.UTF_8);
+        Files.write(file, payload);
+        OtaPackageInfo info = new OtaPackageInfo();
+        info.setId(new OtaPackageId(pkgUuid));
+        when(restClient.saveOtaPackageData(any(OtaPackageId.class), eq("abc123"), eq(ChecksumAlgorithm.MD5), any(String.class), any(byte[].class)))
+                .thenReturn(info);
+
+        String result = tools.saveOtaPackageData(pkgUuid.toString(), file.toString(), "md5", "abc123");
+
+        ArgumentCaptor<OtaPackageId> idCaptor = ArgumentCaptor.forClass(OtaPackageId.class);
+        ArgumentCaptor<String> fileNameCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<byte[]> bytesCaptor = ArgumentCaptor.forClass(byte[].class);
+        verify(restClient).saveOtaPackageData(idCaptor.capture(), eq("abc123"), eq(ChecksumAlgorithm.MD5), fileNameCaptor.capture(), bytesCaptor.capture());
+        assertThat(idCaptor.getValue().getId()).isEqualTo(pkgUuid);
+        assertThat(fileNameCaptor.getValue()).isEqualTo(file.getFileName().toString());
+        assertThat(bytesCaptor.getValue()).isEqualTo(payload);
+        assertThat(result).isEqualTo(JacksonUtil.toString(info));
+    }
+
+    @Test
+    void testSaveOtaPackageDataFileNotFound() throws Exception {
+        UUID pkgUuid = UUID.randomUUID();
+        Path missing = tempDir.resolve("missing.bin");
+
+        String result = tools.saveOtaPackageData(pkgUuid.toString(), missing.toString(), null, null);
+
+        assertThat(result).contains("File not found");
+    }
+
+    @Test
+    void testDownloadOtaPackageToDirectory() throws Exception {
+        UUID pkgUuid = UUID.randomUUID();
+        byte[] payload = "ota-download".getBytes(StandardCharsets.UTF_8);
+        Resource resource = new ByteArrayResource(payload) {
+            @Override
+            public String getFilename() {
+                return "ota.bin";
+            }
+        };
+        when(restClient.downloadOtaPackage(any(OtaPackageId.class))).thenReturn(ResponseEntity.ok(resource));
+
+        String result = tools.downloadOtaPackage(pkgUuid.toString(), tempDir.toString());
+
+        Path target = tempDir.resolve("ota.bin");
+        assertThat(Files.exists(target)).isTrue();
+        assertThat(Files.readAllBytes(target)).isEqualTo(payload);
+        assertThat(result).contains("\"status\":\"OK\"");
+    }
+
+    @Test
+    void testDownloadOtaPackageNoBody() throws Exception {
+        UUID pkgUuid = UUID.randomUUID();
+        when(restClient.downloadOtaPackage(any(OtaPackageId.class))).thenReturn(ResponseEntity.ok().build());
+
+        String result = tools.downloadOtaPackage(pkgUuid.toString(), tempDir.toString());
+
+        assertThat(result).contains("No data returned for OTA package download");
+    }
+
+    @Test
+    void testGetOtaPackageInfoById() {
+        UUID pkgUuid = UUID.randomUUID();
+        OtaPackageInfo info = new OtaPackageInfo();
+        info.setId(new OtaPackageId(pkgUuid));
+        when(restClient.getOtaPackageInfoById(any(OtaPackageId.class))).thenReturn(info);
+
+        String result = tools.getOtaPackageInfoById(pkgUuid.toString());
+
+        ArgumentCaptor<OtaPackageId> idCaptor = ArgumentCaptor.forClass(OtaPackageId.class);
+        verify(restClient).getOtaPackageInfoById(idCaptor.capture());
+        assertThat(idCaptor.getValue().getId()).isEqualTo(pkgUuid);
+        assertThat(result).isEqualTo(JacksonUtil.toString(info));
+    }
+
+    @Test
+    void testGetOtaPackageById() {
+        UUID pkgUuid = UUID.randomUUID();
+        OtaPackage otaPackage = new OtaPackage();
+        otaPackage.setId(new OtaPackageId(pkgUuid));
+        when(restClient.getOtaPackageById(any(OtaPackageId.class))).thenReturn(otaPackage);
+
+        String result = tools.getOtaPackageById(pkgUuid.toString());
+
+        ArgumentCaptor<OtaPackageId> idCaptor = ArgumentCaptor.forClass(OtaPackageId.class);
+        verify(restClient).getOtaPackageById(idCaptor.capture());
+        assertThat(idCaptor.getValue().getId()).isEqualTo(pkgUuid);
+        assertThat(result).isEqualTo(JacksonUtil.toString(otaPackage));
+    }
+
+    @Test
+    void testGetOtaPackages() throws Exception {
+        List<OtaPackageInfo> packages = new ArrayList<>();
+        for (int i = 0; i < 3; i++) {
+            OtaPackageInfo info = new OtaPackageInfo();
+            info.setId(new OtaPackageId(UUID.randomUUID()));
+            packages.add(info);
+        }
+        PageData<OtaPackageInfo> pageData = new PageData<>(packages, 1, packages.size(), false);
+        when(restClient.getOtaPackages(any(PageLink.class))).thenReturn(pageData);
+
+        String result = tools.getOtaPackages("10", "2", "firmware", "createdTime", "DESC");
+
+        verify(restClient).getOtaPackages(pageLinkCaptor.capture());
+        PageLink pageLink = pageLinkCaptor.getValue();
+        assertThat(pageLink.getPageSize()).isEqualTo(10);
+        assertThat(pageLink.getPage()).isEqualTo(2);
+        assertThat(pageLink.getTextSearch()).isEqualTo("firmware");
+        assertThat(pageLink.getSortOrder().getProperty()).isEqualTo("createdTime");
+        assertThat(pageLink.getSortOrder().getDirection()).isEqualTo(SortOrder.Direction.DESC);
+
+        assertThat(result).isEqualTo(JacksonUtil.toString(pageData));
+    }
+
+    @Test
+    void testGetOtaPackagesByDeviceProfile() throws Exception {
+        UUID profileUuid = UUID.randomUUID();
+        List<OtaPackageInfo> packages = new ArrayList<>();
+        for (int i = 0; i < 2; i++) {
+            OtaPackageInfo info = new OtaPackageInfo();
+            info.setId(new OtaPackageId(UUID.randomUUID()));
+            packages.add(info);
+        }
+        PageData<OtaPackageInfo> pageData = new PageData<>(packages, 1, packages.size(), true);
+        when(restClient.getOtaPackages(any(DeviceProfileId.class), eq(OtaPackageType.FIRMWARE), eq(false), any(PageLink.class)))
+                .thenReturn(pageData);
+
+        String result = tools.getOtaPackagesByDeviceProfile(profileUuid.toString(), "FIRMWARE", false, "15", "0", "v1", "title", "ASC");
+
+        ArgumentCaptor<DeviceProfileId> profileCaptor = ArgumentCaptor.forClass(DeviceProfileId.class);
+        verify(restClient).getOtaPackages(profileCaptor.capture(), eq(OtaPackageType.FIRMWARE), eq(false), pageLinkCaptor.capture());
+        assertThat(profileCaptor.getValue().getId()).isEqualTo(profileUuid);
+        PageLink pageLink = pageLinkCaptor.getValue();
+        assertThat(pageLink.getPageSize()).isEqualTo(15);
+        assertThat(pageLink.getPage()).isEqualTo(0);
+        assertThat(pageLink.getTextSearch()).isEqualTo("v1");
+        assertThat(pageLink.getSortOrder().getProperty()).isEqualTo("title");
+        assertThat(pageLink.getSortOrder().getDirection()).isEqualTo(SortOrder.Direction.ASC);
+
+        assertThat(result).isEqualTo(JacksonUtil.toString(pageData));
+    }
+
+    @Test
+    void testCountByDeviceProfileAndEmptyOtaPackage() {
+        UUID profileUuid = UUID.randomUUID();
+        when(restClient.countByDeviceProfileAndEmptyOtaPackage(eq(OtaPackageType.SOFTWARE), any(DeviceProfileId.class)))
+                .thenReturn(7L);
+
+        String result = tools.countByDeviceProfileAndEmptyOtaPackage(profileUuid.toString(), "software");
+
+        ArgumentCaptor<DeviceProfileId> profileCaptor = ArgumentCaptor.forClass(DeviceProfileId.class);
+        verify(restClient).countByDeviceProfileAndEmptyOtaPackage(eq(OtaPackageType.SOFTWARE), profileCaptor.capture());
+        assertThat(profileCaptor.getValue().getId()).isEqualTo(profileUuid);
+        assertThat(result).isEqualTo(JacksonUtil.toString(Map.of("count", 7L)));
+    }
+
+    @Test
+    void testAssignOtaPackageToDeviceFirmware() {
+        UUID deviceUuid = UUID.randomUUID();
+        UUID otaUuid = UUID.randomUUID();
+        Device device = new Device();
+        device.setId(new DeviceId(deviceUuid));
+        when(restClient.getDeviceById(any(DeviceId.class))).thenReturn(Optional.of(device));
+        when(restClient.saveDevice(any(Device.class))).thenReturn(device);
+
+        String result = tools.assignOtaPackageToDevice(deviceUuid.toString(), otaUuid.toString(), "FIRMWARE", false);
+
+        ArgumentCaptor<Device> deviceCaptor = ArgumentCaptor.forClass(Device.class);
+        verify(restClient).saveDevice(deviceCaptor.capture());
+        assertThat(deviceCaptor.getValue().getFirmwareId().getId()).isEqualTo(otaUuid);
+        assertThat(result).isEqualTo(JacksonUtil.toString(device));
+    }
+
+    @Test
+    void testAssignOtaPackageToDeviceProfileSoftware() {
+        UUID profileUuid = UUID.randomUUID();
+        UUID otaUuid = UUID.randomUUID();
+        DeviceProfile profile = new DeviceProfile();
+        profile.setId(new DeviceProfileId(profileUuid));
+        when(restClient.getDeviceProfileById(any(DeviceProfileId.class))).thenReturn(Optional.of(profile));
+        when(restClient.saveDeviceProfile(any(DeviceProfile.class))).thenReturn(profile);
+
+        String result = tools.assignOtaPackageToDeviceProfile(profileUuid.toString(), otaUuid.toString(), "software", false);
+
+        ArgumentCaptor<DeviceProfile> profileCaptor = ArgumentCaptor.forClass(DeviceProfile.class);
+        verify(restClient).saveDeviceProfile(profileCaptor.capture());
+        assertThat(profileCaptor.getValue().getSoftwareId().getId()).isEqualTo(otaUuid);
+        assertThat(result).isEqualTo(JacksonUtil.toString(profile));
+    }
+
+    @Test
+    void testDeleteOtaPackage() {
+        UUID otaUuid = UUID.randomUUID();
+
+        String result = tools.deleteOtaPackage(otaUuid.toString());
+
+        ArgumentCaptor<OtaPackageId> idCaptor = ArgumentCaptor.forClass(OtaPackageId.class);
+        verify(restClient).deleteOtaPackage(idCaptor.capture());
+        assertThat(idCaptor.getValue().getId()).isEqualTo(otaUuid);
+        assertThat(result).isEqualTo("{\"status\":\"OK\",\"id\":\"" + otaUuid + "\"}");
+    }
+}

--- a/src/test/java/org/thingsboard/ai/mcp/server/service/tools/TelemetryToolsTest.java
+++ b/src/test/java/org/thingsboard/ai/mcp/server/service/tools/TelemetryToolsTest.java
@@ -145,11 +145,10 @@ public class TelemetryToolsTest {
     @Test
     void testFindLatestTimeseries_nullKeys() {
         UUID id = UUID.randomUUID();
-        Map<String, Object> body = Map.of(
-                "temperature",
-                List.of(Map.of("ts", 1, "value", "22"))
+        List<TsKvEntry> body = List.of(
+                new BasicTsKvEntry(1L, new DoubleDataEntry("temperature", 22.0))
         );
-        when(restClient.getLatestTimeseries(any(EntityId.class), anyList(), eq(false))).thenReturn((Map) body);
+        when(restClient.getLatestTimeseries(any(EntityId.class), anyList(), eq(false))).thenReturn(body);
 
         String result = tools.getLatestTimeseries("DEVICE", id.toString(), null, "false");
 


### PR DESCRIPTION
## Summary
- add OTA package tools (create/update info, upload/download data, list/get/delete, assign/clear to device/profile)
- expose OTA endpoints in the REST client
- document OTA tools in README
- support optional manual checksum (if you already have an official hash); otherwise ThingsBoard computes it

## Notes
- checksum is passed as `checkSum` only when provided
- supports `checksumAlgorithm` (MD5/SHA256/SHA384/SHA512; default SHA256)

## Testing
- manual MCP calls against ThingsBoard CE (create package, upload, list, assign/clear)

Refs #20