### PR TITLE
Migration to Java 25

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -3,7 +3,7 @@
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
 ## Project Overview
-Spring Boot MCP (Model Context Protocol) server that exposes ThingsBoard IoT platform operations as tools for LLMs. Supports STDIO and SSE transport modes. Built on Spring AI MCP Server (`spring-ai-starter-mcp-server-webmvc` 1.1.2) with ThingsBoard REST client 4.4.0-SNAPSHOT.
+Spring Boot MCP (Model Context Protocol) server that exposes ThingsBoard IoT platform operations as tools for LLMs. Supports STDIO and SSE transport modes. Built on Spring AI MCP Server (`spring-ai-starter-mcp-server-webmvc` 1.1.2) with ThingsBoard REST client 4.3.0PE.
 
 ## Build & Test
 ```bash

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -3,7 +3,7 @@
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
 ## Project Overview
-Spring Boot MCP (Model Context Protocol) server that exposes ThingsBoard IoT platform operations as tools for LLMs. Supports STDIO and SSE transport modes. Built on Spring AI MCP Server (`spring-ai-starter-mcp-server-webmvc` 1.1.2) with ThingsBoard REST client 4.3.0PE.
+Spring Boot MCP (Model Context Protocol) server that exposes ThingsBoard IoT platform operations as tools for LLMs. Supports STDIO and SSE transport modes. Built on Spring AI MCP Server (`spring-ai-starter-mcp-server-webmvc` 1.1.2) with ThingsBoard REST client 4.4.0-SNAPSHOT.
 
 ## Build & Test
 ```bash
@@ -12,16 +12,16 @@ mvn test                          # Run all tests (171 tests)
 mvn test -Dtest=AlarmToolsTest    # Run single test class
 mvn package -DskipTests           # Build JAR only
 ```
-- Java 17, Maven 3.6+
-- JAR output: `target/thingsboard-mcp-server-2.1.0.jar`
+- Java 25, Maven 3.6+
+- JAR output: `target/thingsboard-mcp-server-2.2.0.jar`
 
 ## Run
 ```bash
 # STDIO mode (default)
-java -jar target/thingsboard-mcp-server-2.1.0.jar
+java -jar target/thingsboard-mcp-server-2.2.0.jar
 
 # SSE mode (HTTP on port 8000)
-java -Dspring.ai.mcp.server.stdio=false -Dspring.main.web-application-type=servlet -jar target/thingsboard-mcp-server-2.1.0.jar
+java -Dspring.ai.mcp.server.stdio=false -Dspring.main.web-application-type=servlet -jar target/thingsboard-mcp-server-2.2.0.jar
 ```
 Required env vars: `THINGSBOARD_URL`, `THINGSBOARD_API_KEY` (or legacy `THINGSBOARD_USERNAME`/`THINGSBOARD_PASSWORD`)
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,7 +9,7 @@ Please include a summary of the change and which issue is fixed.
 - [ ] Docs only
 
 ## Checklist
-- [ ] Code builds on Java 17 / Maven 3.6+
+- [ ] Code builds on Java 25 / Maven 3.6+
 - [ ] Unit tests added/updated (where applicable)
 - [ ] Docs updated (README, examples, env var notes)
 - [ ] No breaking API changes (or documented under “Breaking changes”)

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .idea/**
 *.iml
 target/
+.claude

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ Please review our [Code of Conduct](CODE_OF_CONDUCT.md) before contributing. By 
 ## 🛠 Development Setup
 
 ### Prerequisites
-- **Java 17**
+- **Java 25**
 - **Maven 3.6+**
 - Docker (optional, for container testing)
 - Git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build the project using Maven
-FROM maven:3.9.4-eclipse-temurin-21 AS builder
+FROM maven:3.9.4-eclipse-temurin-25 AS builder
 
 WORKDIR /app
 COPY . .
@@ -7,7 +7,7 @@ COPY . .
 RUN mvn clean package -DskipTests
 
 # Stage 2: Runtime container
-FROM eclipse-temurin:21-jre
+FROM eclipse-temurin:25-jre
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build the project using Maven
-FROM maven:3.9.4-eclipse-temurin-25 AS builder
+FROM maven:3.9.12-eclipse-temurin-25 AS builder
 
 WORKDIR /app
 COPY . .

--- a/README.md
+++ b/README.md
@@ -1,517 +1,498 @@
 # ThingsBoard MCP Server
 
-[![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://github.com/thingsboard/mcp-server/blob/master/README.md)
+[![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://github.com/thingsboard/mcp-server/blob/master/LICENSE)
+[![Docker](https://img.shields.io/docker/v/thingsboard/mcp?label=Docker%20Hub&sort=semver)](https://hub.docker.com/r/thingsboard/mcp)
+[![Java](https://img.shields.io/badge/Java-25%2B-orange)](https://github.com/thingsboard/mcp-server)
 
-## Table of Contents
+Connect AI agents to your [ThingsBoard](https://thingsboard.io) IoT platform via [Model Context Protocol (MCP)](https://modelcontextprotocol.io). Query devices, manage entities, analyze telemetry, and automate operations — all through natural language.
 
-- [Overview](#overview)
-- [Requirements](#requirements)
-- [Features](#features)
-    - [Entity Operations](#entity-operations)
-    - [Telemetry Management](#telemetry-management)
-    - [Relations](#relations)
-    - [Alarms](#alarms)
-    - [OTA Packages](#ota-packages)
-    - [Entity Data Query](#entity-data-query)
-- [Quick Start Guide](#quick-start-guide)
-- [Installation](#installation)
-    - [Docker Image](#docker-image)
-    - [Build from Sources](#build-from-sources)
-- [Client Configuration](#client-configuration)
-    - [Binary Configuration](#binary-configuration)
-    - [Docker Configuration](#docker-configuration)
-- [Environment Variables](#environment-variables)
-- [Tool Groups Configuration](#tool-groups-configuration)
-- [Available Tools](#available-tools)
-    - [Device Tools](#device-tools)
-    - [Asset Tools](#asset-tools)
-    - [Customer Tools](#customer-tools)
-    - [User Tools](#user-tools)
-    - [Alarm Tools](#alarm-tools)
-    - [OTA Tools](#ota-tools)
-    - [Entity Group Tools](#entity-group-tools-pe)
-    - [Relation Tools](#relation-tools)
-    - [Telemetry Tools](#telemetry-tools)
+Works with Claude Desktop, Cursor, VS Code Copilot, Claude Code, and any MCP-compatible client.
 
-## Overview
+## Quick Start
 
-The ThingsBoard MCP Server provides a **natural language interface** for LLMs and AI agents to interact with your ThingsBoard IoT platform.
+You need a ThingsBoard instance ([Cloud](https://thingsboard.cloud), [EU Cloud](https://eu.thingsboard.cloud), [self-hosted CE/PE](https://thingsboard.io/docs/user-guide/install/installation-options/), or [Edge](https://thingsboard.io/docs/user-guide/install/edge/installation-options/)) and an API key (ThingsBoard 4.3+) or username/password.
 
-You can ask questions such as “Get my devices of type 'Air Quality Sensor'” and receive structured results:
+<details open>
+<summary><b>Claude Desktop</b></summary>
 
-![Get My Devices Example](images/get_my_devices_example.png)
+Add to your `claude_desktop_config.json`:
 
-You can request to simulate or save time-series data in ThingsBoard:
+```json
+{
+  "mcpServers": {
+    "thingsboard": {
+      "command": "docker",
+      "args": ["run", "-i", "--rm", "-e", "THINGSBOARD_URL", "-e", "THINGSBOARD_API_KEY", "thingsboard/mcp"],
+      "env": {
+        "THINGSBOARD_URL": "https://thingsboard.cloud",
+        "THINGSBOARD_API_KEY": "YOUR_API_KEY"
+      }
+    }
+  }
+}
+```
 
-![Generate Sample Data Example](images/generate_sample_data_example.png)
+</details>
 
-![Generated Data In ThingsBoard](images/generated_data_in_tb_example.png)
+<details>
+<summary><b>Cursor</b></summary>
 
-Or, you can ask it to analyze your time-series data to find anomalies, spikes, or data gaps:
+Add to `~/.cursor/mcp.json` (global) or `.cursor/mcp.json` (project):
 
-![Analyze Data Example](images/analyze_data_example.png)
+```json
+{
+  "mcpServers": {
+    "thingsboard": {
+      "command": "docker",
+      "args": ["run", "-i", "--rm", "-e", "THINGSBOARD_URL", "-e", "THINGSBOARD_API_KEY", "thingsboard/mcp"],
+      "env": {
+        "THINGSBOARD_URL": "https://thingsboard.cloud",
+        "THINGSBOARD_API_KEY": "YOUR_API_KEY"
+      }
+    }
+  }
+}
+```
 
-![Analyze Data Result](images/analyze_result_example.png)
+</details>
 
-This server implements the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/docs/getting-started/intro), which enables AI systems to
-access and manipulate data in ThingsBoard through natural language commands. With this integration, you can:
+<details>
+<summary><b>VS Code Copilot</b></summary>
 
-- Query entities (device, asset, customer, etc.) data and telemetry using conversational language
-- Manage entities through AI assistants
-- Analyze IoT data and create reports using AI tools
-- Automate ThingsBoard operations through AI-powered workflows
+Add to your VS Code `settings.json` or `.vscode/mcp.json`:
 
-The server integrates seamlessly with MCP clients such as Claude Desktop, Cursor, and other AI applications that support the MCP protocol.
+```json
+{
+  "mcp": {
+    "servers": {
+      "thingsboard": {
+        "command": "docker",
+        "args": ["run", "-i", "--rm", "-e", "THINGSBOARD_URL", "-e", "THINGSBOARD_API_KEY", "thingsboard/mcp"],
+        "env": {
+          "THINGSBOARD_URL": "https://thingsboard.cloud",
+          "THINGSBOARD_API_KEY": "YOUR_API_KEY"
+        }
+      }
+    }
+  }
+}
+```
 
-## Requirements
+</details>
 
-Before you begin, ensure you have the following:
+<details>
+<summary><b>Claude Code</b></summary>
 
-- **ThingsBoard instance** - A running ThingsBoard instance that the MCP server can connect to. You can use any of the following options:
-    - **Local/On-premise Community Edition**: Self-hosted installation on your
-      own [infrastructure](https://thingsboard.io/docs/user-guide/install/installation-options/), or
-    - **Local/On-premise Professional Edition**: Self-hosted installation on your
-      own [infrastructure](https://thingsboard.io/docs/user-guide/install/pe/installation-options/), or
-    - **ThingsBoard Demo**: Free shared instance at [demo.thingsboard.io](https://demo.thingsboard.io), or
-    - **ThingsBoard Cloud**: Fully managed cloud service at [thingsboard.cloud](https://thingsboard.cloud), or
-    - **EU ThingsBoard Cloud**: Fully managed cloud service at [eu.thingsboard.cloud](https://eu.thingsboard.cloud), or
-    - **ThingsBoard Edge instance** [up and running](https://thingsboard.io/docs/user-guide/install/edge/installation-options/)
-- **Authentication credentials** - An API key (recommended for ThingsBoard 4.3+) or username/password with appropriate permissions
+```bash
+claude mcp add thingsboard \
+  -e THINGSBOARD_URL=https://thingsboard.cloud \
+  -e THINGSBOARD_API_KEY=YOUR_API_KEY \
+  -- docker run -i --rm -e THINGSBOARD_URL -e THINGSBOARD_API_KEY thingsboard/mcp
+```
 
-## Quick Start Guide
+</details>
 
-1. **Configure your MCP client**: Add the ThingsBoard MCP server to your client configuration (see [Client Configuration](#client-configuration))
-2. **Start using natural language**: Begin interacting with your ThingsBoard instance through your MCP client
+<details>
+<summary><b>SSE Mode (any HTTP-based MCP client)</b></summary>
 
-## Features
+Start the server:
 
-### Entity Operations
+```bash
+docker run --rm -p 8000:8000 \
+  -e THINGSBOARD_URL=https://thingsboard.cloud \
+  -e THINGSBOARD_API_KEY=YOUR_API_KEY \
+  -e SPRING_AI_MCP_SERVER_STDIO=false \
+  -e SPRING_WEB_APPLICATION_TYPE=servlet \
+  thingsboard/mcp
+```
 
-- **Devices**: Create, delete, view device details, credentials, and manage device relationships
-- **Assets**: Create, delete, view, and manage asset relationships
-- **Customers**: Create, delete, access customer information, titles, and manage customer relationships
-- **Users**: Create, delete, manage users, tokens, activation links, and user assignments
-- **Entity Groups**: Create, delete, view entity groups. Assign/unassign entities to specific group.
+Then point your MCP client to `http://localhost:8000/sse`.
 
-### Telemetry Management
+</details>
 
-- **Attribute Access**: Retrieve attribute keys and values by scope for any entity
-- **Time-series Access**: Get time-series data with various aggregation options
-- **Telemetry Insert/Update**: Save attributes or time-series data with optional TTL settings
+> **Legacy auth**: If your ThingsBoard version is older than 4.3, use `THINGSBOARD_USERNAME` and `THINGSBOARD_PASSWORD` instead of `THINGSBOARD_API_KEY`.
 
-### Relations
+## What You Can Do
 
-Create, delete, discover, and navigate relationships between entities with direction-based queries.
+Ask questions in natural language and get structured results from your ThingsBoard instance:
 
-### Alarms
+| | |
+|---|---|
+| **Query devices and entities** | **Analyze time-series data** |
+| ![Get My Devices](images/get_my_devices_example.png) | ![Analyze Data](images/analyze_data_example.png) |
+| **Generate and save telemetry** | **Get anomaly analysis** |
+| ![Generate Data](images/generate_sample_data_example.png) | ![Analysis Result](images/analyze_result_example.png) |
 
-Create, delete, fetch alarms, alarm types, and severity information for specific entities.
+**120+ tools** across 10 tool groups:
 
-### OTA Packages
-
-Create, upload, list, download, and delete OTA packages for device firmware/software updates.
-
-### Entity Data Query
-
-Run complex queries over platform entities (devices, assets, customers, etc.) and retrieve their data (fields, attributes, telemetry) in a structured,
-paginated format.
+- **Devices** — create, update, delete, list, search by name/type/group
+- **Assets** — CRUD, list by tenant/customer, search
+- **Customers** — CRUD, list, search by title
+- **Users** — CRUD, list, admin/customer user management
+- **Alarms** — create, acknowledge, clear, delete, query by severity
+- **Telemetry** — read/write attributes and time-series, aggregation, TTL
+- **Relations** — create, delete, navigate entity relationships
+- **OTA Packages** — upload, download, assign firmware/software to devices
+- **Entity Groups** (PE) — manage groups, assign/remove entities
+- **Entity Data Query** — complex filtered queries across all entity types with attribute/telemetry filters
 
 ## Installation
 
-This MCP server works with ThingsBoard IoT Platform or ThingsBoard Edge. You'll need your ThingsBoard instance or Edge URL and valid credentials for
-the installation.
-
-### ThingsBoard Account
-
-Before installing the MCP server, ensure you have:
-
-1. Access to a ThingsBoard or Edge instance
-2. A user account with sufficient permissions
-3. An API key (ThingsBoard 4.3+) or the username and password for this account
-
-### Docker Image
-
-The easiest way to get started is with the pre-built Docker image from Docker Hub.
-
-#### Server Modes
-
-The ThingsBoard MCP Server can run in two different modes:
-
-- **STDIO Mode (Standard Input/Output)**: The server communicates directly through standard input/output streams
-- **SSE Mode (Server-Sent Events)**: The server runs as an HTTP server that clients connect to
-
-#### Running in STDIO Mode (Default)
-
-For STDIO Mode, you must include the `-i` flag to keep stdin open:
+### Docker (Recommended)
 
 ```bash
 docker pull thingsboard/mcp
-docker run --rm -i -e THINGSBOARD_URL=<your_thingsboard_url> -e THINGSBOARD_API_KEY=<your_api_key> thingsboard/mcp
 ```
 
-#### Running in SSE Mode
+The Docker image supports two transport modes:
 
-In SSE Mode, you must expose port 8000 using the `-p` flag and explicitly override the default settings :
+- **STDIO** (default) — for clients that launch the server as a subprocess (Claude Desktop, Cursor, etc.)
+- **SSE** — for clients that connect over HTTP
+
+See [Quick Start](#quick-start) for usage examples.
+
+### Download Binary
 
 ```bash
-docker pull thingsboard/mcp
-docker run --rm -p 8000:8000 -e THINGSBOARD_URL=<your_thingsboard_url> -e THINGSBOARD_API_KEY=<your_api_key> -e SPRING_AI_MCP_SERVER_STDIO=false -e SPRING_WEB_APPLICATION_TYPE=servlet thingsboard/mcp
+wget https://github.com/thingsboard/mcp-server/releases/download/v2.2.0/thingsboard-mcp-server-2.2.0.jar
 ```
 
-### Download release binary
-
-Alternatively, you can download the release binary (JAR file) and use it with the LLM Agent.
-Run the following command to download the binary to your PC:
+Run with:
 
 ```bash
-wget https://github.com/thingsboard/thingsboard-mcp/releases/download/v2.2.0/thingsboard-mcp-server-2.2.0.jar
+# STDIO mode
+java -jar thingsboard-mcp-server-2.2.0.jar
+
+# SSE mode
+java -Dspring.ai.mcp.server.stdio=false -Dspring.main.web-application-type=servlet -jar thingsboard-mcp-server-2.2.0.jar
 ```
 
-### Build from Sources
+<details>
+<summary><b>Binary client configuration</b></summary>
 
-You can also build the JAR file from sources and run the ThingsBoard MCP Server directly.
+If you're using the JAR file instead of Docker, use this in your `claude_desktop_config.json`:
 
-#### Prerequisites
+```json
+{
+  "mcpServers": {
+    "thingsboard": {
+      "command": "java",
+      "args": ["-jar", "/absolute/path/to/thingsboard-mcp-server-2.2.0.jar"],
+      "env": {
+        "THINGSBOARD_URL": "https://thingsboard.cloud",
+        "THINGSBOARD_API_KEY": "YOUR_API_KEY"
+      }
+    }
+  }
+}
+```
 
-- Java 25 or later
-- Maven 3.6 or later
+</details>
 
-#### Build Steps
+### Build from Source
 
-1. Clone this repository
-2. Build the project:
+Requires Java 25+ and Maven 3.6+.
 
 ```bash
+git clone https://github.com/thingsboard/mcp-server.git
+cd mcp-server
 mvn clean install -DskipTests
+java -jar target/thingsboard-mcp-server-2.2.0.jar
 ```
 
-3. The JAR file will be available in the target folder:
+## Configuration
 
-```bash
-./target/thingsboard-mcp-server-2.2.0.jar
-```
+### Environment Variables
 
-4. Run the server using the JAR file:
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `THINGSBOARD_URL` | Base URL of your ThingsBoard instance | *required* |
+| `THINGSBOARD_API_KEY` | API key for authentication (recommended for 4.3+) | |
+| `THINGSBOARD_USERNAME` | Username for authentication (legacy) | |
+| `THINGSBOARD_PASSWORD` | Password for authentication (legacy) | |
+| `THINGSBOARD_LOGIN_INTERVAL_SECONDS` | Session refresh interval | `1800` |
+| `HTTP_BIND_ADDRESS` | HTTP bind address (SSE mode) | `127.0.0.1` |
+| `HTTP_BIND_PORT` | HTTP port (SSE mode) | `8000` |
+| `SPRING_AI_MCP_SERVER_STDIO` | Enable STDIO transport | `true` |
+| `SPRING_WEB_APPLICATION_TYPE` | `none` for STDIO, `servlet` for SSE | `none` |
+| `SPRING_AI_MCP_SERVER_SSE_ENDPOINT` | SSE endpoint path | `/sse` |
+| `SPRING_AI_MCP_SERVER_SSE_MESSAGE_ENDPOINT` | SSE message endpoint path | `/mcp/message` |
 
-```bash
-# For STDIO Mode
-java -jar ./target/thingsboard-mcp-server-2.2.0.jar
-```
+<details>
+<summary><b>Advanced: connection and logging</b></summary>
 
-```bash
-# For SSE Mode
-java -Dspring.ai.mcp.server.stdio=false -Dspring.main.web-application-type=servlet -jar ./target/thingsboard-mcp-server-2.2.0.jar
-```
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `THINGSBOARD_CONNECTION_MAX_RETRIES` | Max connection retry attempts | `3` |
+| `THINGSBOARD_CONNECTION_RETRY_DELAY_SECONDS` | Delay between retries | `5` |
+| `THINGSBOARD_CONNECTION_CONNECT_TIMEOUT_SECONDS` | HTTP connect timeout | `10` |
+| `THINGSBOARD_CONNECTION_READ_TIMEOUT_SECONDS` | HTTP read timeout | `60` |
+| `LOG_LEVEL_APP` | Application log level | `info` |
+| `LOG_LEVEL_TOOLS` | Tool execution log level | `info` |
+| `LOG_LEVEL_TOOL_RESPONSE` | Tool response log level | `info` |
+| `LOGGING_PATTERN_CONSOLE` | Logback console pattern | `%d{yyyy-MM-dd HH:mm:ss} \| %-5level \| %logger{1} \| %msg%n` |
+| `LOGGING_CONSOLE_TARGET` | Log output target | `System.err` |
 
-## Client Configuration
+</details>
 
-To launch the server as a container when your MCP client starts (e.g., Claude Desktop), you need to add the appropriate configuration to your client's
-settings.
+### Tool Groups
 
-### Docker Configuration
+The server exposes **120+ tools** which may exceed context limits for some clients. Disable groups you don't need:
 
-If you're using the Docker image, use this configuration in your `claude_desktop_config.json`:
+| Variable | Group | Tools | Default |
+|----------|-------|-------|---------|
+| `THINGSBOARD_TOOLS_EDQ` | Entity Data Query + Guides | 40 | `true` |
+| `THINGSBOARD_TOOLS_TELEMETRY` | Telemetry & Attributes | 11 | `true` |
+| `THINGSBOARD_TOOLS_DEVICE` | Devices | 11 | `true` |
+| `THINGSBOARD_TOOLS_ASSET` | Assets | 8 | `true` |
+| `THINGSBOARD_TOOLS_ALARM` | Alarms | 9 | `true` |
+| `THINGSBOARD_TOOLS_OTA` | OTA Packages | 11 | `true` |
+| `THINGSBOARD_TOOLS_RELATION` | Relations | 8 | `true` |
+| `THINGSBOARD_TOOLS_CUSTOMER` | Customers | 7 | `true` |
+| `THINGSBOARD_TOOLS_USER` | Users | 9 | `true` |
+| `THINGSBOARD_TOOLS_GROUP` | Entity Groups (PE only) | 10 | `true` |
+
+**Example** — reduce to ~50 tools for clients with limited context:
 
 ```json
 {
-    "mcpServers": {
-        "thingsboard": {
-            "command": "docker",
-            "args": [
-                "run",
-                "-i",
-                "--rm",
-                "-e",
-                "THINGSBOARD_URL",
-                "-e",
-                "THINGSBOARD_API_KEY",
-                "thingsboard/mcp"
-            ],
-            "env": {
-                "THINGSBOARD_URL": "<thingsboard_url>",
-                "THINGSBOARD_API_KEY": "<your_api_key>"
-            }
-        }
-    }
+  "env": {
+    "THINGSBOARD_TOOLS_EDQ": "false",
+    "THINGSBOARD_TOOLS_OTA": "false",
+    "THINGSBOARD_TOOLS_GROUP": "false",
+    "THINGSBOARD_TOOLS_USER": "false"
+  }
 }
 ```
-
-### Binary Configuration
-
-If you've built the JAR file from sources, use this configuration in your `claude_desktop_config.json`:
-
-```json
-{
-    "mcpServers": {
-        "thingsboard": {
-            "command": "java",
-            "args": [
-                "-jar",
-                "/absolute/path/to/thingsboard-mcp-server-2.2.0.jar"
-            ],
-            "env": {
-                "THINGSBOARD_URL": "<thingsboard_url>",
-                "THINGSBOARD_API_KEY": "<your_api_key>"
-            }
-        }
-    }
-}
-```
-
-## Environment Variables
-
-The MCP server requires the following environment variables to connect to your ThingsBoard instance:
-
-| Variable                                    | Description                                       | Default      |
-|---------------------------------------------|---------------------------------------------------|--------------|
-| `THINGSBOARD_URL`                           | The base URL of your ThingsBoard instance         |              |
-| `THINGSBOARD_API_KEY`                       | API key for authentication (recommended for 4.3+) |              |
-| `THINGSBOARD_USERNAME`                      | Username for authentication (legacy)              |              |
-| `THINGSBOARD_PASSWORD`                      | Password for authentication (legacy)              |              |
-| `THINGSBOARD_LOGIN_INTERVAL_SECONDS`        | Login session refresh interval in seconds         | 1800         |
-| `SPRING_WEB_APPLICATION_TYPE`               | Spring application type (none or servlet)         | none         |
-| `SPRING_AI_MCP_SERVER_STDIO`                | Enable/disable standard I/O communication         | true         |
-| `SPRING_AI_MCP_SERVER_SSE_ENDPOINT`         | Server-Sent Events (SSE) endpoint URL             | /sse         |
-| `SPRING_AI_MCP_SERVER_SSE_MESSAGE_ENDPOINT` | Server-Sent Events message endpoint URL           | /mcp/message |
-| `LOGGING_PATTERN_CONSOLE`                   | Logback console log pattern (must not be empty)   | `%d{yyyy-MM-dd HH:mm:ss} \| %-5level \| %logger{1} \| %msg%n` |
-| `LOGGING_CONSOLE_TARGET`                    | Log output target (`System.err` or `System.out`)  | System.err   |
-| `HTTP_BIND_PORT`                            | HTTP server port number                           | 8000         |
-
-**Authentication**: Since ThingsBoard 4.3, we recommend using API keys instead of username/password. Create an API key in ThingsBoard UI under your user profile.
-
-These variables can be set either:
-
-- Directly via Docker command line using the `-e` flag
-- Or through the `env` configuration block in your MCP client setup
-
-## Tool Groups Configuration
-
-The MCP server provides **120+ tools** which may exceed context limits for some MCP clients (e.g., Claude Desktop). You can disable entire tool groups to reduce the tool count and context size.
-
-### Tool Group Environment Variables
-
-| Variable                    | Description                                      | Default | Tools |
-|-----------------------------|--------------------------------------------------|---------|-------|
-| `THINGSBOARD_TOOLS_EDQ`     | Entity Data Query tools + Guide tools            | true    | 40    |
-| `THINGSBOARD_TOOLS_TELEMETRY` | Telemetry and attributes tools                 | true    | 11    |
-| `THINGSBOARD_TOOLS_DEVICE`  | Device management tools                          | true    | 11    |
-| `THINGSBOARD_TOOLS_ASSET`   | Asset management tools                           | true    | 8     |
-| `THINGSBOARD_TOOLS_ALARM`   | Alarm management tools                           | true    | 9     |
-| `THINGSBOARD_TOOLS_OTA`     | OTA package management tools                     | true    | 11    |
-| `THINGSBOARD_TOOLS_RELATION`| Relation management tools                        | true    | 8     |
-| `THINGSBOARD_TOOLS_CUSTOMER`| Customer management tools                        | true    | 7     |
-| `THINGSBOARD_TOOLS_USER`    | User management tools                            | true    | 9     |
-| `THINGSBOARD_TOOLS_GROUP`   | Entity Group tools (PE only)                     | true    | 10    |
-
-### Recommended Configuration for Claude Desktop
-
-If you experience "Context size exceeds the limit" errors, disable some tool groups:
-
-```json
-{
-    "mcpServers": {
-        "thingsboard": {
-            "command": "java",
-            "args": ["-jar", "/path/to/thingsboard-mcp-server-2.2.0.jar"],
-            "env": {
-                "THINGSBOARD_URL": "<thingsboard_url>",
-                "THINGSBOARD_API_KEY": "<your_api_key>",
-                "THINGSBOARD_TOOLS_EDQ": "false",
-                "THINGSBOARD_TOOLS_OTA": "false",
-                "THINGSBOARD_TOOLS_GROUP": "false",
-                "THINGSBOARD_TOOLS_USER": "false"
-            }
-        }
-    }
-}
-```
-
-This configuration reduces the tool count from ~120 to ~50 tools, which should work with most MCP clients.
 
 ## Available Tools
 
-The ThingsBoard MCP Server provides a wide range of tools that can be used through natural language commands. These tools are organized by category.
+<details>
+<summary><b>Device Tools (11)</b></summary>
 
-### Device Tools
+| Tool | Description |
+|------|-------------|
+| `createOrUpsertDevice` | Create or update a device by name. Primary tool for most device tasks. |
+| `saveDevice` | Create or update the device object from raw JSON. Advanced tool. |
+| `deleteDevice` | Delete the device by id. |
+| `getDeviceById` | Fetch the Device object based on the provided Device Id. |
+| `getDeviceCredentialsByDeviceId` | Get device credentials by device id. |
+| `getTenantDevices` | Returns a page of devices owned by tenant. |
+| `getTenantDevice` | Get tenant device by name. |
+| `getCustomerDevices` | Returns a page of devices assigned to customer. |
+| `getUserDevices` **(PE)** | Returns a page of devices available for the current user. |
+| `getDevicesByIds` | Get devices by ids. |
+| `getDevicesByEntityGroupId` **(PE)** | Returns a page of devices in a specified entity group. |
 
-| Tool                             | Description                                                                                                                                                  |
-|----------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `createOrUpsertDevice`           | Create or update a device by name. Primary tool for most device tasks.                                                                                       |
-| `saveDevice`                     | Create or update the device object from raw JSON. Advanced tool.                                                                                             |
-| `deleteDevice`                   | Delete the device by id.                                                                                                                                     |
-| `getDeviceById`                  | Fetch the Device object based on the provided Device Id.                                                                                                     |
-| `getDeviceCredentialsByDeviceId` | Get device credentials by device id. If during device creation there wasn't specified any credentials, platform generates random 'ACCESS_TOKEN' credentials. |
-| `getTenantDevices`               | Returns a page of devices owned by tenant.                                                                                                                   |
-| `getTenantDevice`                | Get tenant device by name. Device name is a unique property of device.                                                                                       |
-| `getCustomerDevices`             | Returns a page of devices objects assigned to customer.                                                                                                      |
-| `getUserDevices`  **(PE)**       | Returns a page of device objects available for the current user.                                                                                             |
-| `getDevicesByIds`                | Get Devices By Ids. Requested devices must be owned by tenant or assigned to customer.                                                                       |
-| `getDevicesByEntityGroupId` **(PE)** | Returns a page of device objects that belongs to specified Entity Group Id.                                                                              |
+</details>
 
-### Asset Tools
+<details>
+<summary><b>Asset Tools (8)</b></summary>
 
-| Tool                       | Description                                                                          |
-|----------------------------|--------------------------------------------------------------------------------------|
-| `saveAsset`                | Create or update the asset object.                                                   |
-| `deleteAsset`              | Delete the asset by id.                                                              |
-| `getAssetById`             | Get the Asset object based on the provided Asset Id.                                 |
-| `getTenantAssets`          | Returns a page of assets owned by tenant.                                            |
-| `getTenantAsset`           | Get tenant asset by name. Asset name is a unique property of asset.                  |
-| `getCustomerAssets`             | Returns a page of assets objects assigned to customer.                               |
-| `getUserAssets`  **(PE)**       | Returns a page of assets objects available for the current user.                     |
-| `getAssetsByEntityGroupId` **(PE)** | Returns a page of asset objects that belongs to specified Entity Group Id.       |
+| Tool | Description |
+|------|-------------|
+| `saveAsset` | Create or update the asset object. |
+| `deleteAsset` | Delete the asset by id. |
+| `getAssetById` | Get the Asset object by id. |
+| `getTenantAssets` | Returns a page of assets owned by tenant. |
+| `getTenantAsset` | Get tenant asset by name. |
+| `getCustomerAssets` | Returns a page of assets assigned to customer. |
+| `getUserAssets` **(PE)** | Returns a page of assets available for the current user. |
+| `getAssetsByEntityGroupId` **(PE)** | Returns a page of assets in a specified entity group. |
 
-### Customer Tools
+</details>
 
-| Tool                          | Description                                                                   |
-|-------------------------------|-------------------------------------------------------------------------------|
-| `saveCustomer`                | Create or update the customer object.                                         |
-| `deleteCustomer`              | Delete the customer by id.                                                    |
-| `getCustomerById`             | Get the Customer object based on the provided Customer Id.                    |
-| `getCustomers`                | Returns a page of customers owned by tenant.                                  |
-| `getTenantCustomer`           | Get the Customer using Customer Title.                                        |
-| `getUserCustomers`  **(PE)**          | Returns a page of customers available for the user.                           |
-| `getCustomersByEntityGroupId` **(PE)** | Returns a page of Customer objects that belongs to specified Entity Group Id. |
+<details>
+<summary><b>Customer Tools (7)</b></summary>
 
-### User Tools
+| Tool | Description |
+|------|-------------|
+| `saveCustomer` | Create or update the customer object. |
+| `deleteCustomer` | Delete the customer by id. |
+| `getCustomerById` | Get the Customer object by id. |
+| `getCustomers` | Returns a page of customers owned by tenant. |
+| `getTenantCustomer` | Get customer by title. |
+| `getUserCustomers` **(PE)** | Returns a page of customers available for the user. |
+| `getCustomersByEntityGroupId` **(PE)** | Returns a page of customers in a specified entity group. |
 
-| Tool                               | Description                                                                    |
-|------------------------------------|--------------------------------------------------------------------------------|
-| `saveUser`                         | Create or update the user object.                                              |
-| `deleteUser`                       | Delete the user by id.                                                         |
-| `getUserById`                      | Fetch the User object based on the provided User Id.                           |
-| `getUsers`                         | Returns a page of users owned by tenant or customer.                           |
-| `getTenantAdmins`                  | Returns a page of tenant administrator users assigned to the specified tenant. |
-| `getCustomerUsers`                 | Returns a page of users assigned to the specified customer.                    |
-| `getAllCustomerUsers`  **(PE)**    | Returns a page of users for the current tenant with authority 'CUSTOMER_USER'. |
-| `getUsersForAssign`                | Returns page of user data objects that can be assigned to provided alarmId.    |
-| `getUsersByEntityGroupId` **(PE)** | Returns a page of user objects that belongs to specified Entity Group Id.      |
+</details>
 
-### Alarm Tools
+<details>
+<summary><b>User Tools (9)</b></summary>
 
-| Tool                      | Description                                                                                                  |
-|---------------------------|--------------------------------------------------------------------------------------------------------------|
-| `saveAlarm`               | Create or update the alarm object.                                                                           |
-| `deleteAlarm`             | Delete the alarm by id.                                                                                      |
-| `ackAlarm`                | Acknowledge the alarm.                                                                                       |
-| `clearAlarm`              | Clear the alarm.                                                                                             |
-| `getAlarmInfoById`        | Get the Alarm info object based on the provided alarm id (includes originator name).                         |
-| `getAlarms`               | Get a page of alarms for the selected entity.                                                                |
-| `getAllAlarms`            | Get a page of alarms that belongs to the current user owner.                                                 |
-| `getHighestAlarmSeverity` | Get highest alarm severity by originator and optional status filters.                                        |
-| `getAlarmTypes`           | Get a set of unique alarm types based on alarms that are either owned by tenant or assigned to the customer. |
+| Tool | Description |
+|------|-------------|
+| `saveUser` | Create or update the user object. |
+| `deleteUser` | Delete the user by id. |
+| `getUserById` | Fetch the User object by id. |
+| `getUsers` | Returns a page of users owned by tenant or customer. |
+| `getTenantAdmins` | Returns a page of tenant administrator users. |
+| `getCustomerUsers` | Returns a page of users assigned to a customer. |
+| `getAllCustomerUsers` **(PE)** | Returns a page of all customer users for the current tenant. |
+| `getUsersForAssign` | Returns users that can be assigned to an alarm. |
+| `getUsersByEntityGroupId` **(PE)** | Returns a page of users in a specified entity group. |
 
-### OTA Tools
+</details>
 
-| Tool                             | Description                                                                 |
-|----------------------------------|-----------------------------------------------------------------------------|
-| `saveOtaPackageInfo`             | Create or update OTA package info.                                          |
-| `saveOtaPackageData`             | Upload OTA package binary data from a file path on the MCP host. Provide `checksum` only if you already have an official hash. |
-| `downloadOtaPackage`             | Download OTA package binary to a local file path on the MCP host.           |
-| `getOtaPackageInfoById`          | Get OTA package info by id.                                                 |
-| `getOtaPackageById`              | Get OTA package by id.                                                      |
-| `getOtaPackages`                 | Get OTA packages (paged).                                                   |
-| `getOtaPackagesByDeviceProfile`  | Get OTA packages by device profile and type (paged).                        |
-| `assignOtaPackageToDevice`       | Assign or clear OTA package for a device.                                   |
-| `assignOtaPackageToDeviceProfile`| Assign or clear OTA package for a device profile.                           |
-| `countByDeviceProfileAndEmptyOtaPackage` | Count devices in a profile without assigned OTA package.           |
-| `deleteOtaPackage`               | Delete OTA package by id.                                                   |
+<details>
+<summary><b>Alarm Tools (9)</b></summary>
 
-### Entity Group Tools (PE)
+| Tool | Description |
+|------|-------------|
+| `saveAlarm` | Create or update the alarm object. |
+| `deleteAlarm` | Delete the alarm by id. |
+| `ackAlarm` | Acknowledge the alarm. |
+| `clearAlarm` | Clear the alarm. |
+| `getAlarmInfoById` | Get alarm info by id (includes originator name). |
+| `getAlarms` | Get a page of alarms for the selected entity. |
+| `getAllAlarms` | Get a page of alarms for the current user owner. |
+| `getHighestAlarmSeverity` | Get highest alarm severity by originator. |
+| `getAlarmTypes` | Get unique alarm types. |
 
-| Tool                                  | Description                                                                                 |
-|---------------------------------------|---------------------------------------------------------------------------------------------|
-| `saveEntityGroup`                     | Create or update the entity group object.                                                   |
-| `deleteEntityGroup`                   | Delete the entity group by id.                                                              |
-| `getEntityGroupById`                  | Fetch the Entity Group object based on the provided Entity Group Id.                        |
-| `getEntityGroupsByType`               | Fetch the list of Entity Group Info objects based on the provided Entity Type.              |
-| `getEntityGroupByOwnerAndNameAndType` | Fetch the Entity Group object based on the provided owner, type and name.                   |
-| `getEntityGroupsByOwnerAndType`       | Fetch the list of Entity Group Info objects based on the provided Owner Id and Entity Type. |
-| `getEntityGroupsForEntity`            | Returns a list of groups that contain the specified Entity Id.                              |
-| `getEntityGroupsByIds`                | Fetch the list of Entity Group Info objects based on the provided entity group ids list.    |
-| `addEntitiesToEntityGroup`            | Add entities to an entity group.                                                           |
-| `removeEntitiesFromEntityGroup`       | Remove entities from an entity group.                                                      |
+</details>
 
-### Relation Tools
+<details>
+<summary><b>OTA Tools (11)</b></summary>
 
-| Tool                         | Description                                                                                                       |
-|------------------------------|-------------------------------------------------------------------------------------------------------------------|
-| `saveRelation`               | Create or update the relation object.                                                                             |
-| `deleteRelation`             | Delete a relation between two entities.                                                                           |
-| `deleteRelations`            | Delete all relations (both 'from' and 'to' directions) for the specified entity within the COMMON relation group. |
-| `getRelation`                | Returns relation object between two specified entities if present.                                                |
-| `findInfoByFrom`             | Returns list of relation info objects for the specified entity by the 'from' direction (includes entity names).   |
-| `findByFromWithRelationType` | Returns list of relation objects for the specified entity by the 'from' direction and relation type.              |
-| `findInfoByTo`               | Returns list of relation info objects for the specified entity by the 'to' direction (includes entity names).     |
-| `findByToWithRelationType`   | Returns list of relation objects for the specified entity by the 'to' direction and relation type.                |
+| Tool | Description |
+|------|-------------|
+| `saveOtaPackageInfo` | Create or update OTA package info. |
+| `saveOtaPackageData` | Upload OTA package binary from a file path. |
+| `downloadOtaPackage` | Download OTA package binary to a local file path. |
+| `getOtaPackageInfoById` | Get OTA package info by id. |
+| `getOtaPackageById` | Get OTA package by id. |
+| `getOtaPackages` | Get OTA packages (paged). |
+| `getOtaPackagesByDeviceProfile` | Get OTA packages by device profile and type. |
+| `assignOtaPackageToDevice` | Assign or clear OTA package for a device. |
+| `assignOtaPackageToDeviceProfile` | Assign or clear OTA package for a device profile. |
+| `countByDeviceProfileAndEmptyOtaPackage` | Count devices without assigned OTA package. |
+| `deleteOtaPackage` | Delete OTA package by id. |
 
-### Telemetry Tools
+</details>
 
-| Tool                         | Description                                                          |
-|------------------------------|----------------------------------------------------------------------|
-| `getAttributeKeys`           | Get all attribute keys for the specified entity.                     |
-| `getAttributeKeysByScope`    | Get all attribute keys for the specified entity and scope.           |
-| `getAttributes`              | Get attributes for the specified entity.                             |
-| `getAttributesByScope`       | Get attributes for the specified entity and scope.                   |
-| `getTimeseriesKeys`          | Get all time-series keys for the specified entity.                   |
-| `getLatestTimeseries`        | Get the latest time-series values for the specified entity and keys. |
-| `getTimeseries`              | Get time-series data for the specified entity, keys, and time range. |
-| `saveDeviceAttributes`       | Save device attributes.                                              |
-| `saveEntityAttributesV2`     | Save entity attributes.                                              |
-| `saveEntityTelemetry`        | Save entity telemetry data.                                          |
-| `saveEntityTelemetryWithTTL` | Save entity telemetry data with time-to-live (TTL).                  |
+<details>
+<summary><b>Relation Tools (8)</b></summary>
 
-### Guide Tools
+| Tool | Description |
+|------|-------------|
+| `saveRelation` | Create or update a relation. |
+| `deleteRelation` | Delete a relation between two entities. |
+| `deleteRelations` | Delete all relations for an entity. |
+| `getRelation` | Get a relation between two entities. |
+| `findInfoByFrom` | Find relations from an entity (includes entity names). |
+| `findByFromWithRelationType` | Find relations from an entity filtered by type. |
+| `findInfoByTo` | Find relations to an entity (includes entity names). |
+| `findByToWithRelationType` | Find relations to an entity filtered by type. |
 
-| Tool                | Description                                                                              |
-|---------------------|------------------------------------------------------------------------------------------|
-| `getEdqGuide`       | Get documentation for creating Entity Data Queries.                                      |
-| `getEdqCountGuide`  | Get documentation for creating Entity Count Queries.                                     |
-| `getKeyFiltersGuide`| Get documentation and JSON schema for creating key filters (predicates over attributes/telemetry). |
+</details>
 
-### Entity Data Query Tools
+<details>
+<summary><b>Telemetry Tools (11)</b></summary>
 
-| Tool                                               | Description                                                                                                                                                   |
-|----------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `findEntityDataBySingleEntityFilter`               | Find data for **one entity by ID**. Select entity fields, latest attributes/telemetry; optional key filters for expressions over fields/attributes/latest TS. |
-| `findEntityDataByEntityGroupFilter` **(PE)**       | Find data for entities using an **Entity Group** filter (group type + id). Supports fields/latest values and optional key filters.                            |
-| `findEntityDataByEntityListFilter`                 | Find data for a **list of entity IDs** (same type). Supports fields/latest values and optional key filters.                                                   |
-| `findEntityDataByEntityNameFilter`                 | Find data by **name starts-with** filter (same type). Supports fields/latest values and optional key filters.                                                 |
-| `findEntityDataByEntityTypeFilter`                 | Find data by **entity type** (CUSTOMER, USER, DASHBOARD, ASSET, DEVICE, EDGE, ENTITY_VIEW, etc.). Supports fields/latest values and optional key filters.     |
-| `findEntityDataByEntityGroupListFilter` **(PE)**   | Find data for **multiple groups** of the same type using group IDs. Supports fields/latest values and optional key filters.                                   |
-| `findEntityDataByEntityGroupNameFilter` **(PE)**   | Find data for groups by **group type** and **group name starts-with**. Supports fields/latest values and optional key filters.                                |
-| `findEntityDataByEntitiesGroupNameFilter` **(PE)** | Find data for entities that belong to a **group (by type + group name)**. Supports fields/latest values and optional key filters.                             |
-| `findEntityDataByStateEntityOwnerFilter`           | Find data for the **owner (Tenant/Customer)** of a specified entity. Supports fields/latest values and optional key filters.                                  |
-| `findEntityDataByAssetTypeFilter`                  | Find **assets** by **type** and **name starts-with**. Supports fields/latest values and optional key filters.                                                 |
-| `findEntityDataByDeviceTypeFilter`                 | Find **devices** by **type** and **name starts-with**. Supports fields/latest values and optional key filters.                                                |
-| `findEntityDataByEdgeTypeFilter`                   | Find **edges** by **type** and **name starts-with**. Supports fields/latest values and optional key filters.                                                  |
-| `findEntityDataByEntityViewTypeFilter`             | Find **entity views** by **type** and **name starts-with**. Supports fields/latest values and optional key filters.                                           |
-| `findEntityDataByRelationsQueryFilter`             | Find entities **related** to a root entity (by relation query). Supports fields/latest values and optional key filters.                                       |
-| `findEntityDataByAssetSearchQueryFilter`           | Find **assets related** to a root entity (by relation type + allowed asset types). Supports fields/latest values and optional key filters.                    |
-| `findEntityDataByDeviceSearchQueryFilter`          | Find **devices related** to a root entity (by relation type + allowed device types). Supports fields/latest values and optional key filters.                  |
-| `findEntityDataByEntityViewSearchQueryFilter`      | Find **entity views related** to a root entity (by relation type + allowed view types). Supports fields/latest values and optional key filters.               |
-| `findEntityDataByApiUsageStateFilter`              | Find **API usage** data (tenant or customer-scoped). Supports fields/latest values and optional key filters.                                                  |
-| `findEntityDataByEdgeQueryFilter`                  | Find **edges related** to a root entity (by relation type + allowed edge types). Supports fields/latest values and optional key filters.                      |
+| Tool | Description |
+|------|-------------|
+| `getAttributeKeys` | Get all attribute keys for an entity. |
+| `getAttributeKeysByScope` | Get attribute keys by scope. |
+| `getAttributes` | Get attributes for an entity. |
+| `getAttributesByScope` | Get attributes by scope. |
+| `getTimeseriesKeys` | Get all time-series keys for an entity. |
+| `getLatestTimeseries` | Get latest time-series values. |
+| `getTimeseries` | Get time-series data for a time range. |
+| `saveDeviceAttributes` | Save device attributes. |
+| `saveEntityAttributesV2` | Save entity attributes. |
+| `saveEntityTelemetry` | Save entity telemetry data. |
+| `saveEntityTelemetryWithTTL` | Save entity telemetry with TTL. |
 
-### Entity Count Query Tools
+</details>
 
-| Tool                                      | Description                                                                                             |
-|-------------------------------------------|---------------------------------------------------------------------------------------------------------|
-| `countBySingleEntityFilter`               | Count results for a **single entity** by ID with optional key filters.                                  |
-| `countByEntityGroupFilter` **(PE)**       | Count results by **Entity Group** (group type + id) with optional key filters.                          |
-| `countByEntityListFilter`                 | Count results for a **list of entity IDs** (same type) with optional key filters.                       |
-| `countByEntityNameFilter`                 | Count results using **name starts-with** (same type) with optional key filters.                         |
-| `countByEntityTypeFilter`                 | Count results by **entity type** with optional key filters.                                             |
-| `countByEntityGroupListFilter` **(PE)**   | Count results for **multiple groups** (same type) using group IDs with optional key filters.            |
-| `countByEntityGroupNameFilter` **(PE)**   | Count results for groups by **group type** and **group name starts-with** with optional key filters.    |
-| `countByEntitiesGroupNameFilter` **(PE)** | Count results for entities that belong to a **group (by type + group name)** with optional key filters. |
-| `countByAssetTypeFilter`                  | Count **assets** by **type** and **name starts-with** with optional key filters.                        |
-| `countByDeviceTypeFilter`                 | Count **devices** by **type** and **name starts-with** with optional key filters.                       |
-| `countByEdgeTypeFilter`                   | Count **edges** by **type** and **name starts-with** with optional key filters.                         |
-| `countByEntityViewTypeFilter`             | Count **entity views** by **type** and **name starts-with** with optional key filters.                  |
-| `countByApiUsageStateFilter`              | Count API usage rows (optionally scoped by customer) with optional key filters.                         |
-| `countByRelationsQueryFilter`             | Count entities **related** to a root entity with optional key filters.                                  |
-| `countByAssetSearchQueryFilter`           | Count **assets related** to a root entity with optional key filters.                                    |
-| `countByDeviceSearchQueryFilter`          | Count **devices related** to a root entity with optional key filters.                                   |
-| `countByEntityViewSearchQueryFilter`      | Count **entity views related** to a root entity with optional key filters.                              |
-| `countByEdgeQueryFilter`                  | Count **edges related** to a root entity with optional key filters.                                     |
+<details>
+<summary><b>Entity Group Tools — PE only (10)</b></summary>
+
+| Tool | Description |
+|------|-------------|
+| `saveEntityGroup` | Create or update an entity group. |
+| `deleteEntityGroup` | Delete an entity group by id. |
+| `getEntityGroupById` | Get entity group by id. |
+| `getEntityGroupsByType` | Get entity groups by entity type. |
+| `getEntityGroupByOwnerAndNameAndType` | Get entity group by owner, type, and name. |
+| `getEntityGroupsByOwnerAndType` | Get entity groups by owner and type. |
+| `getEntityGroupsForEntity` | Get groups containing a specified entity. |
+| `getEntityGroupsByIds` | Get entity groups by ids. |
+| `addEntitiesToEntityGroup` | Add entities to a group. |
+| `removeEntitiesFromEntityGroup` | Remove entities from a group. |
+
+</details>
+
+<details>
+<summary><b>Entity Data Query Tools (19)</b></summary>
+
+Complex filtered queries across all entity types. Supports entity fields, attributes, and latest telemetry with key filters.
+
+| Tool | Description |
+|------|-------------|
+| `findEntityDataBySingleEntityFilter` | Find data for one entity by ID. |
+| `findEntityDataByEntityGroupFilter` **(PE)** | Find data by entity group. |
+| `findEntityDataByEntityListFilter` | Find data for a list of entity IDs. |
+| `findEntityDataByEntityNameFilter` | Find data by name prefix. |
+| `findEntityDataByEntityTypeFilter` | Find data by entity type. |
+| `findEntityDataByEntityGroupListFilter` **(PE)** | Find data for multiple groups. |
+| `findEntityDataByEntityGroupNameFilter` **(PE)** | Find data for groups by name prefix. |
+| `findEntityDataByEntitiesGroupNameFilter` **(PE)** | Find data for entities in a named group. |
+| `findEntityDataByStateEntityOwnerFilter` | Find data for entity owner. |
+| `findEntityDataByAssetTypeFilter` | Find assets by type. |
+| `findEntityDataByDeviceTypeFilter` | Find devices by type. |
+| `findEntityDataByEdgeTypeFilter` | Find edges by type. |
+| `findEntityDataByEntityViewTypeFilter` | Find entity views by type. |
+| `findEntityDataByRelationsQueryFilter` | Find related entities. |
+| `findEntityDataByAssetSearchQueryFilter` | Find related assets. |
+| `findEntityDataByDeviceSearchQueryFilter` | Find related devices. |
+| `findEntityDataByEntityViewSearchQueryFilter` | Find related entity views. |
+| `findEntityDataByApiUsageStateFilter` | Find API usage data. |
+| `findEntityDataByEdgeQueryFilter` | Find related edges. |
+
+</details>
+
+<details>
+<summary><b>Entity Count Query Tools (18)</b></summary>
+
+Count entities matching filters. Same filter types as Entity Data Query.
+
+| Tool | Description |
+|------|-------------|
+| `countBySingleEntityFilter` | Count by single entity ID. |
+| `countByEntityGroupFilter` **(PE)** | Count by entity group. |
+| `countByEntityListFilter` | Count by entity ID list. |
+| `countByEntityNameFilter` | Count by name prefix. |
+| `countByEntityTypeFilter` | Count by entity type. |
+| `countByEntityGroupListFilter` **(PE)** | Count by multiple groups. |
+| `countByEntityGroupNameFilter` **(PE)** | Count by group name prefix. |
+| `countByEntitiesGroupNameFilter` **(PE)** | Count entities in a named group. |
+| `countByAssetTypeFilter` | Count assets by type. |
+| `countByDeviceTypeFilter` | Count devices by type. |
+| `countByEdgeTypeFilter` | Count edges by type. |
+| `countByEntityViewTypeFilter` | Count entity views by type. |
+| `countByApiUsageStateFilter` | Count API usage rows. |
+| `countByRelationsQueryFilter` | Count related entities. |
+| `countByAssetSearchQueryFilter` | Count related assets. |
+| `countByDeviceSearchQueryFilter` | Count related devices. |
+| `countByEntityViewSearchQueryFilter` | Count related entity views. |
+| `countByEdgeQueryFilter` | Count related edges. |
+
+</details>
+
+<details>
+<summary><b>Guide Tools (3)</b></summary>
+
+Documentation tools that help LLMs construct correct queries.
+
+| Tool | Description |
+|------|-------------|
+| `getEdqGuide` | Get documentation for creating Entity Data Queries. |
+| `getEdqCountGuide` | Get documentation for creating Entity Count Queries. |
+| `getKeyFiltersGuide` | Get documentation for creating key filters. |
+
+</details>
+
+## License
+
+This project is licensed under the Apache License 2.0 — see the [LICENSE](LICENSE) file for details.

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Alternatively, you can download the release binary (JAR file) and use it with th
 Run the following command to download the binary to your PC:
 
 ```bash
-wget https://github.com/thingsboard/thingsboard-mcp/releases/download/v2.1.0/thingsboard-mcp-server-2.1.0.jar
+wget https://github.com/thingsboard/thingsboard-mcp/releases/download/v2.2.0/thingsboard-mcp-server-2.2.0.jar
 ```
 
 ### Build from Sources
@@ -173,7 +173,7 @@ You can also build the JAR file from sources and run the ThingsBoard MCP Server 
 
 #### Prerequisites
 
-- Java 17 or later
+- Java 25 or later
 - Maven 3.6 or later
 
 #### Build Steps
@@ -188,19 +188,19 @@ mvn clean install -DskipTests
 3. The JAR file will be available in the target folder:
 
 ```bash
-./target/thingsboard-mcp-server-2.1.0.jar
+./target/thingsboard-mcp-server-2.2.0.jar
 ```
 
 4. Run the server using the JAR file:
 
 ```bash
 # For STDIO Mode
-java -jar ./target/thingsboard-mcp-server-2.1.0.jar
+java -jar ./target/thingsboard-mcp-server-2.2.0.jar
 ```
 
 ```bash
 # For SSE Mode
-java -Dspring.ai.mcp.server.stdio=false -Dspring.main.web-application-type=servlet -jar ./target/thingsboard-mcp-server-2.1.0.jar
+java -Dspring.ai.mcp.server.stdio=false -Dspring.main.web-application-type=servlet -jar ./target/thingsboard-mcp-server-2.2.0.jar
 ```
 
 ## Client Configuration
@@ -247,7 +247,7 @@ If you've built the JAR file from sources, use this configuration in your `claud
             "command": "java",
             "args": [
                 "-jar",
-                "/absolute/path/to/thingsboard-mcp-server-2.1.0.jar"
+                "/absolute/path/to/thingsboard-mcp-server-2.2.0.jar"
             ],
             "env": {
                 "THINGSBOARD_URL": "<thingsboard_url>",
@@ -312,7 +312,7 @@ If you experience "Context size exceeds the limit" errors, disable some tool gro
     "mcpServers": {
         "thingsboard": {
             "command": "java",
-            "args": ["-jar", "/path/to/thingsboard-mcp-server-2.1.0.jar"],
+            "args": ["-jar", "/path/to/thingsboard-mcp-server-2.2.0.jar"],
             "env": {
                 "THINGSBOARD_URL": "<thingsboard_url>",
                 "THINGSBOARD_API_KEY": "<your_api_key>",

--- a/pom.xml
+++ b/pom.xml
@@ -12,10 +12,12 @@
     <properties>
         <spring-boot.version>3.4.10</spring-boot.version>
         <spring.ai.version>1.1.2</spring.ai.version>
-        <thingsboard.version>4.4.0-SNAPSHOT</thingsboard.version>
+        <thingsboard.version>4.3.0PE</thingsboard.version>
         <lombok.version>1.18.40</lombok.version>
         <auth0-jwt.version>4.4.0</auth0-jwt.version>
         <surefire.version>3.2.5</surefire.version>
+        <byte-buddy.version>1.17.7</byte-buddy.version> <!-- override Spring Boot BOM for Java 25 support. TODO: remove when upgrading to Spring Boot 3.5+ -->
+        <mockito.version>5.21.0</mockito.version> <!-- override Spring Boot BOM for Java 25 support. TODO: remove when upgrading to Spring Boot 3.5+ -->
         <json-schema-validator.version>2.0.0</json-schema-validator.version>
         <commons-lang3.version>3.18.0</commons-lang3.version> <!-- to fix CVE-2025-48924. TODO: remove when fixed in spring-boot-dependencies -->
     </properties>
@@ -83,6 +85,28 @@
                         <artifactId>android-json</artifactId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>net.bytebuddy</groupId>
+                <artifactId>byte-buddy</artifactId>
+                <version>${byte-buddy.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>net.bytebuddy</groupId>
+                <artifactId>byte-buddy-agent</artifactId>
+                <version>${byte-buddy.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-core</artifactId>
+                <version>${mockito.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-junit-jupiter</artifactId>
+                <version>${mockito.version}</version>
+                <scope>test</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <properties>
         <spring-boot.version>3.4.10</spring-boot.version>
         <spring.ai.version>1.1.2</spring.ai.version>
-        <thingsboard.version>4.3.0PE</thingsboard.version>
+        <thingsboard.version>4.4.0PE</thingsboard.version>
         <lombok.version>1.18.40</lombok.version>
         <auth0-jwt.version>4.4.0</auth0-jwt.version>
         <surefire.version>3.2.5</surefire.version>

--- a/pom.xml
+++ b/pom.xml
@@ -5,15 +5,15 @@
 
     <groupId>org.thingsboard</groupId>
     <artifactId>thingsboard-mcp-server</artifactId>
-    <version>2.1.0</version>
+    <version>2.2.0</version>
     <name>ThingsBoard MCP server</name>
     <description>MCP server for ThingsBoard platform</description>
 
     <properties>
         <spring-boot.version>3.4.10</spring-boot.version>
         <spring.ai.version>1.1.2</spring.ai.version>
-        <thingsboard.version>4.3.0PE</thingsboard.version>
-        <lombok.version>1.18.32</lombok.version>
+        <thingsboard.version>4.4.0-SNAPSHOT</thingsboard.version>
+        <lombok.version>1.18.40</lombok.version>
         <auth0-jwt.version>4.4.0</auth0-jwt.version>
         <surefire.version>3.2.5</surefire.version>
         <json-schema-validator.version>2.0.0</json-schema-validator.version>
@@ -131,7 +131,7 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.11.0</version>
                 <configuration>
-                    <release>17</release>
+                    <release>25</release>
                     <compilerArgs>
                         <arg>-Xlint:deprecation</arg>
                         <arg>-Xlint:removal</arg>
@@ -159,6 +159,7 @@
                 <configuration>
                     <argLine>
                         -XX:+UseStringDeduplication -XX:MaxGCPauseMillis=20
+                        -XX:+EnableDynamicAgentLoading
                         --add-opens java.base/java.lang.reflect=ALL-UNNAMED
                     </argLine>
                 </configuration>

--- a/src/main/java/org/thingsboard/ai/mcp/server/rest/RestClient.java
+++ b/src/main/java/org/thingsboard/ai/mcp/server/rest/RestClient.java
@@ -4185,7 +4185,7 @@ public class RestClient implements Closeable {
             params.put("force", force);
         }
 
-        UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(baseURL + "/api/customMenu");
+        UriComponentsBuilder builder = UriComponentsBuilder.fromUriString(baseURL + "/api/customMenu");
 
         for (Map.Entry<String, Object> entry : params.entrySet()) {
             builder.queryParam(entry.getKey(), entry.getValue());

--- a/src/test/java/org/thingsboard/ai/mcp/server/service/tools/TelemetryToolsTest.java
+++ b/src/test/java/org/thingsboard/ai/mcp/server/service/tools/TelemetryToolsTest.java
@@ -95,6 +95,7 @@ public class TelemetryToolsTest {
         String result = tools.getAttributes("DEVICE", id.toString(), "temp,model");
 
         ArgumentCaptor<EntityId> entityCap = ArgumentCaptor.forClass(EntityId.class);
+        @SuppressWarnings("unchecked")
         ArgumentCaptor<List<String>> keysCap = ArgumentCaptor.forClass(List.class);
         verify(restClient).getAttributeKvEntries(entityCap.capture(), keysCap.capture());
         assertThat(entityCap.getValue().getId()).isEqualTo(id);
@@ -113,6 +114,7 @@ public class TelemetryToolsTest {
         String result = tools.getAttributes("DEVICE", id.toString(), null);
 
         ArgumentCaptor<EntityId> entityCap = ArgumentCaptor.forClass(EntityId.class);
+        @SuppressWarnings("unchecked")
         ArgumentCaptor<List<String>> keysCap = ArgumentCaptor.forClass(List.class);
         verify(restClient).getAttributeKvEntries(entityCap.capture(), keysCap.capture());
         assertThat(entityCap.getValue().getId()).isEqualTo(id);
@@ -132,6 +134,7 @@ public class TelemetryToolsTest {
 
         ArgumentCaptor<EntityId> entityCap = ArgumentCaptor.forClass(EntityId.class);
         ArgumentCaptor<String> scopeCap = ArgumentCaptor.forClass(String.class);
+        @SuppressWarnings("unchecked")
         ArgumentCaptor<List<String>> keysCap = ArgumentCaptor.forClass(List.class);
         verify(restClient).getAttributesByScope(entityCap.capture(), scopeCap.capture(), keysCap.capture());
         assertThat(entityCap.getValue().getId()).isEqualTo(id);
@@ -153,6 +156,7 @@ public class TelemetryToolsTest {
         String result = tools.getLatestTimeseries("DEVICE", id.toString(), null, "false");
 
         ArgumentCaptor<EntityId> entityCap = ArgumentCaptor.forClass(EntityId.class);
+        @SuppressWarnings("unchecked")
         ArgumentCaptor<List<String>> keysCap = ArgumentCaptor.forClass(List.class);
         verify(restClient).getLatestTimeseries(entityCap.capture(), keysCap.capture(), eq(false));
         assertThat(entityCap.getValue().getId()).isEqualTo(id);
@@ -172,6 +176,7 @@ public class TelemetryToolsTest {
 
         ArgumentCaptor<EntityId> entityCap = ArgumentCaptor.forClass(EntityId.class);
         ArgumentCaptor<String> scopeCap = ArgumentCaptor.forClass(String.class);
+        @SuppressWarnings("unchecked")
         ArgumentCaptor<List<String>> keysCap = ArgumentCaptor.forClass(List.class);
         verify(restClient).getAttributesByScope(entityCap.capture(), scopeCap.capture(), keysCap.capture());
         assertThat(entityCap.getValue().getId()).isEqualTo(id);
@@ -235,6 +240,7 @@ public class TelemetryToolsTest {
         );
 
         ArgumentCaptor<EntityId> entityCap = ArgumentCaptor.forClass(EntityId.class);
+        @SuppressWarnings("unchecked")
         ArgumentCaptor<List<String>> keysCap = ArgumentCaptor.forClass(List.class);
         ArgumentCaptor<Long> intervalCap = ArgumentCaptor.forClass(Long.class);
         ArgumentCaptor<Aggregation> aggCap = ArgumentCaptor.forClass(Aggregation.class);
@@ -314,6 +320,7 @@ public class TelemetryToolsTest {
         );
 
         ArgumentCaptor<EntityId> entityCap = ArgumentCaptor.forClass(EntityId.class);
+        @SuppressWarnings("unchecked")
         ArgumentCaptor<List<String>> keysCap = ArgumentCaptor.forClass(List.class);
         ArgumentCaptor<Long> intervalCap = ArgumentCaptor.forClass(Long.class);
         ArgumentCaptor<Aggregation> aggCap = ArgumentCaptor.forClass(Aggregation.class);


### PR DESCRIPTION
## Summary

- Migrate from Java 17 to Java 25 to align with ThingsBoard 4.4.0
- Bump project version from 2.1.0 to 2.2.0
- Update Lombok from 1.18.32 to 1.18.40 (Java 25 compatible)
- Update Docker images from Eclipse Temurin 21 to 25
- Add `-XX:+EnableDynamicAgentLoading` JVM flag for Mockito/ByteBuddy compatibility in tests

## Changes

| File | Change |
|------|--------|
| `pom.xml` | Version 2.2.0, Java 25 compiler target, Lombok 1.18.40, EnableDynamicAgentLoading |
| `Dockerfile` | `eclipse-temurin-21` -> `eclipse-temurin-25` (build + runtime) |
| `README.md` | Java 25 prerequisite, version 2.2.0 references |
| `CONTRIBUTING.md` | Java 25 prerequisite |
| `.github/PULL_REQUEST_TEMPLATE.md` | Java 25 build checklist |
| `.claude/CLAUDE.md` | Java 25, version 2.2.0 |

## Type of change
- [ ] Bug fix
- [ ] Feature / new MCP tool
- [ ] Refactor / tech debt
- [ ] Docs only

## Checklist
- [ ] Code builds on Java 25 / Maven 3.6+
- [ ] Unit tests added/updated (where applicable)
- [ ] Docs updated (README, examples, env var notes)
- [ ] No breaking API changes (or documented under “Breaking changes”)
- [ ] Docker path tested (STDIO and/or SSE as relevant)
- [ ] Security considerations reviewed (no secrets in code/logs)

## Breaking changes (if any)
**Java 25 is now required** (previously Java 17)